### PR TITLE
feat: add block teaser

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -7,7 +7,7 @@
 #     https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
 #
 
-name: Continous Deplyoment
+name: CD
 
 on:
   push:

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -2,7 +2,7 @@
 # Continues integration pipeline to test every branch.
 #
 
-name: Continous Integration
+name: CI
 
 on: pull_request
 

--- a/src/components/teasers/block-teaser.tsx
+++ b/src/components/teasers/block-teaser.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled from 'styled-components';
+import { up } from '../breakpoint/breakpoint';
+
+const Teaser = styled.div``;
+
+const LeftContainer = styled.div<{ splitView: boolean }>`
+  ${up('md')} {
+    text-align: ${(props) => (props.splitView ? 'right' : 'left')};
+    padding-right: ${(props) => (props.splitView ? '60%' : '0')};
+  }
+`;
+
+const RightContainer = styled.div<{ splitView: boolean }>`
+  ${up('md')} {
+    padding-left: ${(props) => (props.splitView ? '40%' : '0')};
+  }
+`;
+
+const PreTitle = styled.div`
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  opacity: 0.5;
+
+  margin-bottom: 8px;
+`;
+
+const Title = styled.div`
+  font-size: 32px;
+  font-weight: bold;
+
+  margin-bottom: 24px;
+`;
+
+const Text = styled.p`
+  font-size: 16px;
+  line-height: 150%;
+
+  margin-bottom: 16px;
+`;
+
+const Link = styled.a`
+  font-size: 20px;
+  font-weight: bold;
+  color: #4d79ff;
+`;
+
+interface BlockTeaserProps {
+  preTitle: string;
+  title: string;
+  text: string;
+  splitView?: boolean;
+  link?: string;
+}
+
+export const BlockTeaser: React.FC<BlockTeaserProps> = (props) => {
+  return (
+    <Teaser>
+      <LeftContainer splitView={Boolean(props.splitView)}>
+        <PreTitle>{props.preTitle}</PreTitle>
+        <Title>{props.title}</Title>
+      </LeftContainer>
+      <RightContainer splitView={Boolean(props.splitView)}>
+        <Text>{props.text}</Text>
+        <Link>{props.link}</Link>
+      </RightContainer>
+    </Teaser>
+  );
+};

--- a/src/components/teasers/block-teaser.tsx
+++ b/src/components/teasers/block-teaser.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { up } from '../breakpoint/breakpoint';
+import { Link } from 'gatsby';
 
 const Teaser = styled.div``;
 
@@ -33,25 +34,19 @@ const Title = styled.div`
   margin-bottom: 24px;
 `;
 
-const Text = styled.p`
-  font-size: 16px;
-  line-height: 150%;
-
-  margin-bottom: 16px;
-`;
-
-const Link = styled.a`
+const StyledLink = styled(Link)`
   font-size: 20px;
   font-weight: bold;
   color: #4d79ff;
+  text-decoration: none;
 `;
 
 interface BlockTeaserProps {
   preTitle: string;
   title: string;
-  text: string;
   splitView?: boolean;
   link?: string;
+  linkTo?: string;
 }
 
 export const BlockTeaser: React.FC<BlockTeaserProps> = (props) => {
@@ -62,8 +57,10 @@ export const BlockTeaser: React.FC<BlockTeaserProps> = (props) => {
         <Title>{props.title}</Title>
       </LeftContainer>
       <RightContainer splitView={Boolean(props.splitView)}>
-        <Text>{props.text}</Text>
-        <Link>{props.link}</Link>
+        {props.children}
+        {props.link && props.linkTo && (
+          <StyledLink to={props.linkTo}>{props.link}</StyledLink>
+        )}
       </RightContainer>
     </Teaser>
   );

--- a/src/components/teasers/block-teaser.tsx
+++ b/src/components/teasers/block-teaser.tsx
@@ -8,13 +8,15 @@ const Teaser = styled.div``;
 const LeftContainer = styled.div<{ splitView: boolean }>`
   ${up('md')} {
     text-align: ${(props) => (props.splitView ? 'right' : 'left')};
-    padding-right: ${(props) => (props.splitView ? '60%' : '0')};
+    margin-right: ${(props) => (props.splitView ? '60%' : '0')};
+    padding-right: ${(props) => (props.splitView ? '12px' : '0')};
   }
 `;
 
 const RightContainer = styled.div<{ splitView: boolean }>`
   ${up('md')} {
-    padding-left: ${(props) => (props.splitView ? '40%' : '0')};
+    margin-left: ${(props) => (props.splitView ? '40%' : '0')};
+    padding-left: ${(props) => (props.splitView ? '12px' : '0')};
   }
 `;
 

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -18,3 +18,10 @@ export const SectionTitle = styled.h2`
     font-size: 72px;
   }
 `;
+
+export const Text = styled.p`
+  font-size: 16px;
+  line-height: 150%;
+
+  margin-bottom: 16px;
+`;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { PageTitle, SectionTitle } from '../components/typography/typography';
 import styled from 'styled-components';
 import { up } from '../components/breakpoint/breakpoint';
 import { BlockTeaser } from '../components/teasers/block-teaser';
+import { Text } from '../components/typography/typography';
 
 const HomePageTitle = styled(PageTitle)`
   margin-top: 108px;
@@ -51,24 +52,54 @@ const IndexPage: React.FC = () => (
         <BlockTeaser
           preTitle="Services"
           title="Full Stack"
-          text="Satellytes ist eine Digital-Agentur, die um große Unternehmen kreist und ihnen bei der Transformation und Optimierung digitaler Services und Interfaces hilft. Wir bieten „Full Stack“ an, also den gesamten Prozess von Ideation bis zur Implementierung des letzten performanten Funnels und der letzten Zeile wunderschönen Codes."
           link="All Services >"
-        />
+          linkTo="/services"
+        >
+          <Text>
+            Satellytes ist eine Digital-Agentur, die um große Unternehmen kreist
+            und ihnen bei der Transformation und Optimierung digitaler Services
+            und Interfaces hilft. Wir bieten „Full Stack“ an, also den gesamten
+            Prozess von Ideation bis zur Implementierung des letzten
+            performanten Funnels und der letzten Zeile wunderschönen Codes.
+          </Text>
+        </BlockTeaser>
         <HomePageSubTitle>
           We are into relationships, not one-night-stands.
         </HomePageSubTitle>
         <BlockTeaser
           preTitle="Clients"
           title="Long term projects not fire & forget"
-          text="We are showing clients not projects since we are aiming for long term relationships.
-We are really good at creating design systems for complex web applications and self-testing, high performance pattern libraries."
           splitView
-        />
+        >
+          <Text>
+            We are showing clients not projects since we are aiming for long
+            term relationships.
+          </Text>
+          <Text>
+            We are really good at creating design systems for complex web
+            applications and self-testing, high performance pattern libraries.
+          </Text>
+        </BlockTeaser>
         <ClientList>List</ClientList>
         <HomePageSubTitle>
           We are on your side - and the customer&lsquo;s.
         </HomePageSubTitle>
-        <p>Card</p>
+        <BlockTeaser
+          preTitle="About"
+          title="Passionate geeks with high ambitions"
+          link="About us"
+          linkTo="/about"
+          splitView
+        >
+          <Text>
+            We are showing clients not projects since we are aiming for long
+            term relationships.
+          </Text>
+          <Text>
+            We are really good at creating design systems for complex web
+            applications and self-testing, high performance pattern libraries.
+          </Text>
+        </BlockTeaser>
       </GridItem>
     </Grid>
   </Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,8 +6,9 @@ import { Grid, GridItem } from '../components/grid/grid';
 import { PageTitle, SectionTitle } from '../components/typography/typography';
 import styled from 'styled-components';
 import { up } from '../components/breakpoint/breakpoint';
+import { BlockTeaser } from '../components/teasers/block-teaser';
 
-const Title = styled(PageTitle)`
+const HomePageTitle = styled(PageTitle)`
   margin-top: 108px;
   margin-bottom: 280px;
 
@@ -17,7 +18,7 @@ const Title = styled(PageTitle)`
   }
 `;
 
-const SubTitle = styled(SectionTitle)`
+const HomePageSubTitle = styled(SectionTitle)`
   margin-top: 80px;
   margin-bottom: 80px;
 
@@ -27,19 +28,46 @@ const SubTitle = styled(SectionTitle)`
   }
 `;
 
+const ClientList = styled.div`
+  margin-top: 80px;
+  margin-bottom: 80px;
+
+  ${up('md')} {
+    margin-top: 120px;
+    margin-bottom: 160px;
+  }
+`;
+
 const IndexPage: React.FC = () => (
   <Layout>
     <SEO title="Home" />
     <Grid>
       <GridItem xs={0} md={2} />
       <GridItem xs={12} md={8}>
-        <Title>Full Stack Digital Service Agency</Title>
-        <SubTitle>We offer only what we are truly great at.</SubTitle>
-        <p>Card</p>
-        <SubTitle>We are into relationships, not one-night-stands.</SubTitle>
-        <p>Card</p>
-        <p>List</p>
-        <SubTitle>We are on your side - and the customer&lsquo;s.</SubTitle>
+        <HomePageTitle>Full Stack Digital Service Agency</HomePageTitle>
+        <HomePageSubTitle>
+          We offer only what we are truly great at.
+        </HomePageSubTitle>
+        <BlockTeaser
+          preTitle="Services"
+          title="Full Stack"
+          text="Satellytes ist eine Digital-Agentur, die um große Unternehmen kreist und ihnen bei der Transformation und Optimierung digitaler Services und Interfaces hilft. Wir bieten „Full Stack“ an, also den gesamten Prozess von Ideation bis zur Implementierung des letzten performanten Funnels und der letzten Zeile wunderschönen Codes."
+          link="All Services >"
+        />
+        <HomePageSubTitle>
+          We are into relationships, not one-night-stands.
+        </HomePageSubTitle>
+        <BlockTeaser
+          preTitle="Clients"
+          title="Long term projects not fire & forget"
+          text="We are showing clients not projects since we are aiming for long term relationships.
+We are really good at creating design systems for complex web applications and self-testing, high performance pattern libraries."
+          splitView
+        />
+        <ClientList>List</ClientList>
+        <HomePageSubTitle>
+          We are on your side - and the customer&lsquo;s.
+        </HomePageSubTitle>
         <p>Card</p>
       </GridItem>
     </Grid>


### PR DESCRIPTION
This pull request will add the block teaser component. The component has 2 versions:
- a default one, with all content aligned on the left
- a split version, where the pretitle and title are split on the left side, and the rest is on the right side

<details>
 <summary>Mobile</summary>
<img width="786" alt="Bildschirmfoto 2020-04-24 um 18 43 39" src="https://user-images.githubusercontent.com/7814926/80236629-a9f87600-865b-11ea-94d4-891ff6895495.png">
</details>

<details>
 <summary>Desktop</summary>
<img width="1388" alt="Bildschirmfoto 2020-04-24 um 18 43 29" src="https://user-images.githubusercontent.com/7814926/80236652-b2e94780-865b-11ea-86dc-c059cbb44e95.png">
</details>