### PR TITLE
Feat: syw-001 simple page header component

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'gatsby';
+import { up } from '../breakpoint/breakpoint';
 import styled from 'styled-components';
+import BurgerMenu from '../icons/burger-menu';
 
 interface HeaderProps {
   siteTitle: string;
@@ -8,12 +10,19 @@ interface HeaderProps {
 }
 
 const StyledHeader = styled.header<{ light: boolean }>`
-  padding: 16px 24px;
-
+  height: 65px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 16px;
   border-bottom: ${(props) =>
     props.light
       ? '1px solid rgba(255, 255, 255, 0.1)'
       : '1px solid rgba(32, 40, 64, 0.05)'};
+
+  ${up('md')} {
+    padding: 0 24px;
+  }
 `;
 
 /**
@@ -23,24 +32,35 @@ const StyledHeader = styled.header<{ light: boolean }>`
  *
  * Issue: https://github.com/styled-components/styled-components/issues/1198
  */
-const StyledLink = styled(Link)<{ light: number }>`
+const SiteTitle = styled(Link)<{ light: number }>`
   font-size: 20px;
   font-weight: bold;
   text-decoration: none;
-
   color: ${(props) =>
     props.light === 1
       ? props.theme.palette.text.headerLight
       : props.theme.palette.text.header};
 `;
 
+const SiteMenu = styled.div<{ light: number }>`
+  cursor: pointer;
+
+  rect {
+    fill: ${(props) =>
+      props.light === 1
+        ? props.theme.palette.text.headerLight
+        : props.theme.palette.text.header};
+  }
+`;
+
 const Header: React.FC<HeaderProps> = (props) => (
   <StyledHeader light={Boolean(props.light)}>
-    <div>
-      <StyledLink to="/" light={props.light ? 1 : 0}>
-        {props.siteTitle}
-      </StyledLink>
-    </div>
+    <SiteTitle to="/" light={props.light ? 1 : 0}>
+      {props.siteTitle}
+    </SiteTitle>
+    <SiteMenu light={props.light ? 1 : 0}>
+      <BurgerMenu />
+    </SiteMenu>
   </StyledHeader>
 );
 

--- a/src/components/icons/burger-menu.tsx
+++ b/src/components/icons/burger-menu.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const BurgerMenu: React.FC = () => (
+  <svg
+    width="12"
+    height="10"
+    viewBox="0 0 12 10"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="12" height="2" rx="1" fill="#668CFF" />
+    <rect x="2" y="4" width="10" height="2" rx="1" fill="#668CFF" />
+    <rect x="4" y="8" width="8" height="2" rx="1" fill="#668CFF" />
+  </svg>
+);
+
+export default BurgerMenu;


### PR DESCRIPTION
This pull request adds to the the current header component, to match syw-001 ticket requirements. 

Features:
- Add burger menu, with light theme option
- Adjust styling to match design

<details>
<summary>Mobile</summary>

![Screenshot 2020-05-14 at 17 26 07](https://user-images.githubusercontent.com/31735645/81953794-61076200-9608-11ea-97c1-771ca9acc245.png)
</details>

<details>
<summary>Desktop </summary>

![Screenshot 2020-05-14 at 17 25 39](https://user-images.githubusercontent.com/31735645/81953838-7086ab00-9608-11ea-9be4-22c93aaa68f1.png)
</details>

<details>
<summary>Light Theme</summary>

![Screenshot 2020-05-14 at 17 33 21](https://user-images.githubusercontent.com/31735645/81954389-14705680-9609-11ea-8c88-d5be6655c55b.png)
</details>

