### PR TITLE
feat: add card-component

### DIFF
--- a/src/@types/styled-components.d.ts
+++ b/src/@types/styled-components.d.ts
@@ -29,6 +29,7 @@ declare module 'styled-components' {
       background: {
         bodyLight: string;
         body: string;
+        card: string;
         footer: string;
       };
     };

--- a/src/components/cards/card.test.tsx
+++ b/src/components/cards/card.test.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Card } from './card';
+
+const data = {
+  title: 'card title',
+  text: 'text',
+  link: '/link',
+};
+
+describe('Card', () => {
+  it('should render', () => {
+    const card = render(<Card title={data.title} text={data.text} />);
+    expect(card).toBeTruthy();
+  });
+
+  it('should show title', () => {
+    const { getByText } = render(<Card title={data.title} text={data.text} />);
+    expect(getByText(data.title)).toBeTruthy();
+  });
+
+  it('should show text', () => {
+    const { getByText } = render(<Card title={data.title} text={data.text} />);
+    expect(getByText(data.text)).toBeTruthy();
+  });
+
+  it('should show link, when provided', () => {
+    const { getByText } = render(
+      <Card title={data.title} text={data.text} link={data.link} />,
+    );
+
+    expect(getByText(/Apply/)).toBeTruthy();
+  });
+
+  it('link should direct to linked page', () => {
+    const link = data.link;
+    const { getByText } = render(
+      <Card title={data.title} text={data.text} link={link} />,
+    );
+
+    expect(getByText(/Apply/).closest('a')).toHaveAttribute('href', link);
+  });
+});

--- a/src/components/cards/card.tsx
+++ b/src/components/cards/card.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { Link } from 'gatsby';
+import { theme } from '../layout/theme';
+import { up } from '../breakpoint/breakpoint';
+import { GridItem } from '../grid/grid';
+
+export interface CardProps {
+  title: string;
+  text: string;
+  link?: string;
+}
+
+const textStyles = css`
+  color: ${theme.palette.text.default};
+  line-height: 110%;
+`;
+
+export const CardWrapper = styled(GridItem)`
+  background-color: ${theme.palette.background.card};
+
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  margin-bottom: 16px;
+  padding: 24px;
+  border-radius: 4px;
+
+  ${up('md')} {
+    min-height: 365px;
+  }
+`;
+
+export const CardTitle = styled.div`
+  ${textStyles}
+
+  margin-bottom: 24px;
+  font-size: 32px;
+  font-weight: bold;
+`;
+
+export const CardText = styled.p`
+  ${textStyles}
+
+  flex-grow: 1;
+  margin: 0 0 24px;
+  font-size: 14px;
+  line-height: 150%;
+`;
+
+const CardLink = styled(Link)`
+  color: ${theme.palette.text.darkLinkColor.default};
+
+  align-self: flex-end;
+  font-size: 15px;
+  font-weight: bold;
+  line-height: 110%;
+  text-decoration: none;
+
+  &:hover {
+    color: ${theme.palette.text.darkLinkColor.hover};
+  }
+`;
+
+export const Card: React.FC<CardProps> = ({ title, text, link }) => {
+  return (
+    <CardWrapper sm={6} md={4}>
+      <CardTitle>{title}</CardTitle>
+      <CardText>{text}</CardText>
+      {link && <CardLink to={link}>Apply &gt;</CardLink>}
+    </CardWrapper>
+  );
+};

--- a/src/components/client-list/client-list.tsx
+++ b/src/components/client-list/client-list.tsx
@@ -75,6 +75,7 @@ const StyledTitle = styled(Link)`
     margin-bottom: 0;
   }
 `;
+
 const StyledTimestamp = styled.div`
   color: ${theme.palette.text.darkDefault};
   font-size: 16px;

--- a/src/components/layout/theme.tsx
+++ b/src/components/layout/theme.tsx
@@ -6,7 +6,7 @@ export const theme: DefaultTheme = {
       main: '#668CFF',
     },
     text: {
-      default: '#000000',
+      default: '#202840',
       defaultLight: '#FFFFFF',
       header: '#668CFF',
       headerLight: '#FFFFFF',
@@ -19,6 +19,7 @@ export const theme: DefaultTheme = {
     background: {
       body: '#202840',
       bodyLight: '#FFFFFF',
+      card: '#F5F6F7',
       footer: '#4D79FF',
     },
   },

--- a/src/pages/career.tsx
+++ b/src/pages/career.tsx
@@ -4,6 +4,7 @@ import Layout from '../components/layout/layout';
 import SEO from '../components/seo';
 import { PageTitle } from '../components/typography/typography';
 import { Grid, GridItem } from '../components/grid/grid';
+import { Card } from '../components/cards/card';
 
 const CareerPage: React.FC = () => {
   return (
@@ -13,6 +14,13 @@ const CareerPage: React.FC = () => {
         <GridItem>
           <PageTitle>Career</PageTitle>
         </GridItem>
+      </Grid>
+      <Grid>
+        <Card
+          title="Junior UI Designer"
+          text="Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Maecenas sed diam eget risus varius blandit sit amet non magna."
+          link="/"
+        />
       </Grid>
     </Layout>
   );


### PR DESCRIPTION
Code changes/additions include:

✓ add basic **card** component to project
✓ test coverage for **card**
✓ implement one on career page
✓ add a colour to theme palette (incl. types)

Watch live: https://deploy-preview-25--satellytes-website-new.netlify.app/career/
_Note_: Career page will come next, with more cards to see layout better.

<div style="display: flex;">
<img height="250" alt="Card – Mobile" src="https://user-images.githubusercontent.com/29313661/85286216-805c9f00-b492-11ea-9c63-5ed2ed7dd415.png">
<img height="250" alt="Card – Desktop" src="https://user-images.githubusercontent.com/29313661/85286283-a08c5e00-b492-11ea-9645-fe09ca0e1896.png">
</div>

### Screenshots

<details>
 <summary>Mobile</summary>
<img width="100%" alt="Card – Mobile" src="https://user-images.githubusercontent.com/29313661/85286216-805c9f00-b492-11ea-9c63-5ed2ed7dd415.png">
</details>

<details>
 <summary>Desktop
</summary>
<img width="100%" alt="Card – Desktop" src="https://user-images.githubusercontent.com/29313661/85286283-a08c5e00-b492-11ea-9645-fe09ca0e1896.png">
</details>