### PR TITLE
feat: add optional external links to Image-Card component

### DIFF
--- a/src/components/image-card/image-card.tsx
+++ b/src/components/image-card/image-card.tsx
@@ -5,6 +5,7 @@ import {
   ImageCardTitleLarge,
   ImageCardTitle,
   ImageCardSubtitle,
+  ImageCardLink,
 } from '../typography/typography';
 import { up } from '../breakpoint/breakpoint';
 
@@ -14,6 +15,11 @@ interface ImageCardProps {
   title?: string;
   subtitle?: string;
   largeTitle?: boolean;
+  links?: { title: string; url: string }[];
+}
+
+interface ImageCardLinksProps {
+  links: { title: string; url: string }[];
 }
 
 const ImageCardWrapper = styled.div`
@@ -41,12 +47,30 @@ const StyledImageCardSubtitle = styled(ImageCardSubtitle)`
   margin: 0;
 `;
 
+const LinkTitle = styled.div`
+  display: inline-block;
+  margin-right: 14px;
+`;
+
+const ImageCardLinks: React.FC<ImageCardLinksProps> = ({ links }) => {
+  return (
+    <>
+      {links.map((link) => (
+        <ImageCardLink to={link.url} key={link.title}>
+          <LinkTitle>{link.title} &gt;</LinkTitle>
+        </ImageCardLink>
+      ))}
+    </>
+  );
+};
+
 const ImageCard: React.FC<ImageCardProps> = ({
   alt,
   image,
   title,
   largeTitle,
   subtitle,
+  links,
 }) => {
   return (
     <ImageCardWrapper>
@@ -61,6 +85,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
       {subtitle && (
         <StyledImageCardSubtitle>{subtitle}</StyledImageCardSubtitle>
       )}
+      {links && <ImageCardLinks links={links} />}
     </ImageCardWrapper>
   );
 };

--- a/src/components/image-grids/team-member-image-grid.tsx
+++ b/src/components/image-grids/team-member-image-grid.tsx
@@ -5,7 +5,11 @@ import ImageCard from '../image-card/image-card';
 import styled from 'styled-components';
 
 interface TeamMemberImageGridProps {
-  teamMembers: { name: string; role: string }[];
+  teamMembers: {
+    name: string;
+    role: string;
+    links?: { title: string; url: string }[];
+  }[];
   imagePlaceholder: FluidObject;
 }
 
@@ -26,6 +30,7 @@ const TeamMemberImageGrid: React.FC<TeamMemberImageGridProps> = ({
             image={imagePlaceholder}
             title={teamMember.name}
             subtitle={teamMember.role}
+            links={teamMember.links}
           />
         </GridItem>
       ))}

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import { up } from '../breakpoint/breakpoint';
+import { Link } from 'gatsby';
+import { theme } from '../layout/theme';
 
 /**
  *
@@ -101,4 +103,16 @@ export const ImageCardTitle = styled.p`
 export const ImageCardSubtitle = styled.p`
   font-size: 14px;
   line-height: 150%;
+`;
+
+export const ImageCardLink = styled(Link)`
+  color: ${theme.palette.text.darkLinkColor.default};
+  font-size: 14px;
+  line-height: 150%;
+  font-weight: bold;
+  text-decoration: none;
+
+  &:hover {
+    color: ${theme.palette.text.darkLinkColor.hover};
+  }
 `;

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -95,11 +95,39 @@ export default AboutPage;
 
 // TODO: where should we put this data?
 const teamMemberData = [
-  { name: 'Gholam Abdol', role: 'CEO, Partner' },
-  { name: 'Eric Singhartinger', role: 'CEO, CXO, Partner' },
-  { name: 'Georgios Kaleadis', role: 'CTO, Partner' },
+  {
+    name: 'Gholam Abdol',
+    role: 'CEO, Partner',
+    links: [
+      { title: 'LinkedIn', url: 'https://de.linkedin.com/' },
+      { title: 'XING', url: 'https://www.xing.com' },
+    ],
+  },
+  {
+    name: 'Eric Singhartinger',
+    role: 'CEO, CXO, Partner',
+    links: [{ title: 'LinkedIn', url: 'https://de.linkedin.com/' }],
+  },
+  {
+    name: 'Georgios Kaleadis',
+    role: 'CTO, Partner',
+    links: [
+      { title: 'LinkedIn', url: 'https://de.linkedin.com/' },
+      { title: 'XING', url: 'https://www.xing.com' },
+      { title: 'GitHub', url: 'https://www.github.com' },
+    ],
+  },
   { name: 'Mark Altmann', role: 'Backend' },
-  { name: 'Kateryna Bugaieva', role: 'Frontend' },
+  {
+    name: 'Kateryna Bugaieva',
+    role: 'Frontend',
+    links: [
+      { title: 'LinkedIn', url: 'https://de.linkedin.com/' },
+      { title: 'XING', url: 'https://www.xing.com' },
+      { title: 'GitHub', url: 'https://www.github.com' },
+      { title: 'Twitter', url: 'https://www.twitter.com' },
+    ],
+  },
   { name: 'Fabian Dietenberger', role: 'Fullstack' },
   { name: 'Arthur Erdös', role: 'Backend' },
   { name: 'Klara Fleischmann', role: 'Frontend' },


### PR DESCRIPTION
Code changes/additions:

- Image-Card takes an array of link objects as an optional prop. Each link needs a 'title' and a 'url'. These links will display as external links underneath the card title/subtitle. 
- Currently used in Team Member Image Grid (in About page)

**Screenshots:**

<details>
<summary>Team Member Grid Desktop</summary>

![Screenshot 2020-06-25 at 17 32 14](https://user-images.githubusercontent.com/31735645/85750360-eacb4480-b709-11ea-9843-d4888b3b6870.png)
</details>

<details>
<summary>Team Member Grid Mobile</summary>

![Screenshot 2020-06-25 at 17 32 37](https://user-images.githubusercontent.com/31735645/85750418-f880ca00-b709-11ea-9237-7102daa29851.png)
</details>




