### PR TITLE
feat: add swoosh to page title

### DIFF
--- a/src/components/swoosh.tsx
+++ b/src/components/swoosh.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const Swoosh: React.FC = (props: React.SVGAttributes<SVGElement>) => (
+  <svg
+    className={props.className}
+    viewBox="0 0 51 15"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    preserveAspectRatio="xMidYMid meet"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M5.2677 1.62848C-2.24866 4.13097 -0.220584 13.7035 8.33002 9.91382C30.0564 0.284465 50.4749 15 50.4749 15C50.4749 15 27.8129 -5.8777 5.2677 1.62848Z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -1,26 +1,59 @@
+import React from 'react';
 import styled from 'styled-components';
 import { up } from '../breakpoint/breakpoint';
 import { Link } from 'gatsby';
 import { theme } from '../layout/theme';
+import { Swoosh } from '../swoosh';
 
 /**
  *
  * Title
  *
  */
-export const PageTitle = styled.h1`
-  color: #668cff;
-  font-size: 48px;
-  line-height: 110%;
 
+const TitleContainer = styled.div`
+  position: relative;
   margin-top: 96px;
   margin-bottom: 40px;
 
+  color: #668cff;
+
   ${up('md')} {
-    font-size: 72px;
     margin-top: 192px;
   }
 `;
+
+export const TitleSvg = styled(Swoosh)`
+  position: absolute;
+  left: 3px;
+  bottom: calc(100% + 10px);
+  height: 10px;
+
+  ${up('md')} {
+    bottom: calc(100% + 15px);
+    height: 15px;
+  }
+`;
+
+export const StyledTitle = styled.h1`
+  font-size: 48px;
+  line-height: 110%;
+
+  ${up('md')} {
+    font-size: 72px;
+  }
+`;
+
+export const PageTitle: React.FC = (
+  props: React.AllHTMLAttributes<HTMLElement>,
+) => {
+  return (
+    <TitleContainer className={props.className}>
+      <TitleSvg />
+      <StyledTitle>{props.children}</StyledTitle>
+    </TitleContainer>
+  );
+};
 
 export const SectionTitle = styled.h2`
   font-size: 48px;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,12 @@ import React from 'react';
 import Layout from '../components/layout/layout';
 import SEO from '../components/seo';
 import { Grid, GridItem } from '../components/grid/grid';
-import { PageTitle, SectionTitle } from '../components/typography/typography';
+import {
+  PageTitle,
+  SectionTitle,
+  TitleSvg,
+  StyledTitle,
+} from '../components/typography/typography';
 import styled from 'styled-components';
 import { up } from '../components/breakpoint/breakpoint';
 import { BlockTeaser } from '../components/teasers/block-teaser';
@@ -12,16 +17,25 @@ import { ClientList } from '../components/client-list/client-list';
 import { clients } from '../components/client-list/fixtures';
 
 const HomePageTitle = styled(PageTitle)`
-  color: #ffffff;
-
-  font-size: 32px;
-
   margin-top: 108px;
   margin-bottom: 280px;
+
+  color: #ffffff;
 
   ${up('md')} {
     margin-top: 192px;
     margin-bottom: 360px;
+  }
+
+  ${TitleSvg} {
+    left: 2px;
+  }
+
+  ${StyledTitle} {
+    font-size: 32px;
+    ${up('md')} {
+      font-size: 72px;
+    }
   }
 `;
 


### PR DESCRIPTION
before:

![Screenshot 2020-06-30 at 17 19 11](https://user-images.githubusercontent.com/29313661/86144378-e3cf7800-baf5-11ea-9ea8-13b3e0c85923.png)

after:

![Screenshot 2020-06-30 at 17 19 20](https://user-images.githubusercontent.com/29313661/86144402-edf17680-baf5-11ea-9028-4dc88f3771f2.png)

Swoosh on home page title:
https://deploy-preview-29--satellytes-website-new.netlify.app/

Swoosh on page title:
https://deploy-preview-29--satellytes-website-new.netlify.app/clients
https://deploy-preview-29--satellytes-website-new.netlify.app/blog
https://deploy-preview-29--satellytes-website-new.netlify.app/career