### PR TITLE
feat: introduce career form (personio flavour)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,14 +32,10 @@ module.exports = {
   rules: {
     // disabled because of https://github.com/yannickcr/eslint-plugin-react/issues/2353
     'react/prop-types': 'off',
-
-    // to not need to add a return type on styled-components props
-    '@typescript-eslint/explicit-function-return-type': [
-      'error',
-      {
-        allowExpressions: true,
-      },
-    ],
+    // disable some rules that are too strict for the everyday usage for a website
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
   },
   ignorePatterns: ['gatsby-*.js', 'jest', '*.md'],
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@reach/tabs": "^0.13.2",
+    "axios": "^0.21.1",
     "babel-plugin-styled-components": "^1.12.0",
     "date-fns": "^2.19.0",
     "fast-xml-parser": "^3.19.0",
@@ -43,6 +44,7 @@
     "gatsby-transformer-sharp": "3.1.0",
     "modern-normalize": "1.0.0",
     "node-fetch": "^2.6.1",
+    "polished": "^4.1.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "6.1.0",

--- a/src/components/career-form/career-components.tsx
+++ b/src/components/career-form/career-components.tsx
@@ -21,7 +21,11 @@ interface InputFieldProps {
   type?: 'text' | 'file';
 }
 
-export const InputField: React.FC<InputFieldProps> = (props) => {
+export const Container = styled.div`
+  margin-top: 32px;
+`;
+
+export const InputField = (props: InputFieldProps) => {
   return (
     <InputContainer>
       <InputWrapper>

--- a/src/components/career-form/career-components.tsx
+++ b/src/components/career-form/career-components.tsx
@@ -21,7 +21,7 @@ interface InputFieldProps {
   type?: 'text' | 'file';
 }
 
-export const Container = styled.div`
+export const CareerFormStyled = styled.form`
   margin-top: 32px;
 `;
 

--- a/src/components/career-form/career-components.tsx
+++ b/src/components/career-form/career-components.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import {
+  ButtonText,
+  ErrorMessage,
+  Input,
+  InputContainer,
+  InputWrapper,
+  SendButton,
+  SentButton,
+} from '../form/controls';
+import { CheckmarkIcon } from '../icons/buttons-icons/checkmark';
+import styled from 'styled-components';
+import { rgba } from 'polished';
+import { RightArrowIcon } from '../icons/buttons-icons/right-arrow';
+
+interface InputFieldProps {
+  placeholder: string;
+  name: string;
+  error: any;
+  inputRef: any;
+  type?: 'text' | 'file';
+}
+
+export const InputField: React.FC<InputFieldProps> = (props) => {
+  return (
+    <InputContainer>
+      <InputWrapper>
+        <Input
+          placeholder={props.placeholder}
+          type={props.type ?? 'text'}
+          name={props.name}
+          ref={props.inputRef}
+          hasError={props.error}
+        />
+        <FormError error={props.error} />
+      </InputWrapper>
+    </InputContainer>
+  );
+};
+
+export const FormError = ({ error }) => {
+  if (!error) {
+    return null;
+  }
+
+  return (
+    <ErrorMessage>
+      <span>{error.message}</span>
+    </ErrorMessage>
+  );
+};
+
+export const SuccessMessage = () => {
+  return (
+    <div>
+      <p>
+        Danke für deine Bewerbung! Wir haben dir eine E-Mail zur Bestätigung
+        geschickt und melden uns bei dir.
+      </p>
+      <SentButton type="button">
+        <ButtonText>Sent</ButtonText> <CheckmarkIcon />
+      </SentButton>
+    </div>
+  );
+};
+
+const Track = styled.div`
+  height: 4px;
+  background: ${rgba('#202840', 0.1)};
+  border-radius: 2px;
+`;
+
+const Progress = styled.div<{ progress: number }>`
+  ${({ progress }) =>
+    `
+        width: ${Math.ceil(progress * 100)}%;
+    `}
+  height: 100%;
+  background: #668cff;
+  border-radius: 2px;
+`;
+
+export const ProgressBar = ({ progress, isSubmitting }) => {
+  if (!isSubmitting) {
+    return null;
+  }
+
+  return (
+    <Track>
+      <Progress progress={progress} />
+    </Track>
+  );
+};
+
+export const Fieldset = styled.fieldset`
+  border: none;
+  padding: 0;
+  margin: 0;
+`;
+
+export const Actions = ({ tryAgainFn, error, isSubmitting }) => {
+  if (error) {
+    return (
+      <>
+        <FormError error={error} />
+        <p>
+          Versuch es bitte noch einmal. Klappt es nicht dann schicke deine
+          Bewerbung direkt an <strong>career@satellytes.com</strong>
+        </p>
+        <SendButton onClick={() => tryAgainFn()}>
+          <ButtonText>Try Again</ButtonText>
+        </SendButton>
+      </>
+    );
+  }
+
+  return (
+    <SendButton type="submit" disabled={isSubmitting}>
+      <ButtonText>Send</ButtonText>
+      {!isSubmitting && <RightArrowIcon />}
+      {isSubmitting && <span>...</span>}
+    </SendButton>
+  );
+};

--- a/src/components/career-form/career-form.tsx
+++ b/src/components/career-form/career-form.tsx
@@ -1,0 +1,191 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorMessage, TextArea } from '../form/controls';
+import { Grid, GridItem } from '../grid/grid';
+import axios from 'axios';
+import {
+  Actions,
+  Fieldset,
+  InputField,
+  ProgressBar,
+  SuccessMessage,
+} from './career-components';
+
+interface CareerFormProps {
+  recruiting_channel_id: string;
+  job_position_id: string;
+  access_token: string;
+  company_id: string;
+}
+
+type FormData = {
+  first_name: string;
+  last_name: string;
+  email: string;
+  documents: FileList;
+  message: string;
+  phone?: string;
+};
+
+const API_ENDPOINT = 'https://api.personio.de/recruiting/applicant';
+const SIMPLE_EMAIL_PATTERN = /.+@.+\..+/;
+
+export const CareerForm: React.FC<CareerFormProps> = (props) => {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    clearErrors,
+    errors,
+    formState: { isSubmitSuccessful, isSubmitting },
+  } = useForm();
+
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  const onSubmit = async (formValues: FormData): Promise<void> => {
+    const apiData = {
+      company_id: props.company_id,
+      access_token: props.access_token,
+      job_position_id: props.job_position_id, // dev test position
+      recruiting_channel_id: props.recruiting_channel_id, //satellytes.com
+    };
+
+    const payload = {
+      ...apiData,
+      ...formValues,
+    };
+
+    const formData = new FormData();
+
+    for (const [key, value] of Object.entries(payload)) {
+      if (key === 'documents') {
+        formData.append(
+          'documents',
+          formValues.documents[0],
+          formValues.documents[0].name,
+        );
+      }
+      formData.append(key, value as any); // formdata doesn't take objects
+    }
+    // await new Promise(resolve => setTimeout(resolve, 2000));
+    await axios
+      .post(API_ENDPOINT, formData, {
+        onUploadProgress: (progressEvent) =>
+          setUploadProgress(progressEvent.loaded / progressEvent.total),
+      })
+      .then((res) => res.data)
+      .then((json) => {
+        if (json.success) {
+          // all good
+        }
+      })
+      .catch((error) => {
+        // personio seems to deliver a different so the message can be inside the error object or the error object itself
+        const personioErrorMessage =
+          error?.response?.data?.error?.message ??
+          error?.response?.data?.error ??
+          error.message;
+        setError('api', {
+          type: 'server',
+          message: `Irgendetwas ist schief gelaufen (${personioErrorMessage}).`,
+        });
+      });
+  };
+
+  const onError = (event) => {
+    console.log('onError', event);
+  };
+
+  // recover from some previous error
+  const tryAgain = () => {
+    setUploadProgress(0);
+    clearErrors();
+  };
+
+  // early exit if we are done with the submission
+  if (isSubmitSuccessful) {
+    return <SuccessMessage />;
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit, onError)}>
+      <Fieldset disabled={isSubmitting}>
+        <Grid>
+          {/*First Name*/}
+          <GridItem xs={12} md={6}>
+            <InputField
+              inputRef={register({ required: 'Dein Vorname fehlt' })}
+              error={errors.first_name}
+              name="first_name"
+              placeholder="Vorname"
+            />
+          </GridItem>
+
+          {/*Last Name*/}
+          <GridItem xs={12} md={6}>
+            <InputField
+              inputRef={register({ required: 'Dein Nachname fehlt' })}
+              error={errors.last_name}
+              name="last_name"
+              placeholder="Nachname"
+            />
+          </GridItem>
+
+          {/*E-Mail*/}
+          <GridItem xs={12} md={6}>
+            <InputField
+              inputRef={register({
+                required: 'Deine E-Mail fehlt',
+                pattern: {
+                  value: SIMPLE_EMAIL_PATTERN,
+                  message: `Irgendwas stimmt an dieser E-Mail nicht`,
+                },
+              })}
+              error={errors.email}
+              name="email"
+              placeholder="E-Mail-Adresse"
+            />
+          </GridItem>
+
+          {/*CV File */}
+          <GridItem>
+            <InputField
+              inputRef={register({ required: 'Dein CV fehlt' })}
+              error={errors.documents}
+              name="documents"
+              type={'file'}
+              placeholder="E-Mail-Adresse"
+            />
+          </GridItem>
+
+          {/*Cover Letter*/}
+          <GridItem>
+            <TextArea
+              placeholder="Dein Cover Letter"
+              name="message"
+              ref={register({ required: 'Dein Anschreiben fehlt' })}
+              hasError={!!errors.message}
+            />
+            {errors.message && (
+              <ErrorMessage>
+                <span>{errors.message.message}</span>
+              </ErrorMessage>
+            )}
+          </GridItem>
+
+          <GridItem>
+            <ProgressBar
+              isSubmitting={isSubmitting}
+              progress={uploadProgress}
+            />
+            <Actions
+              tryAgainFn={tryAgain}
+              isSubmitting={isSubmitting}
+              error={errors.api}
+            />
+          </GridItem>
+        </Grid>
+      </Fieldset>
+    </form>
+  );
+};

--- a/src/components/career-form/career-form.tsx
+++ b/src/components/career-form/career-form.tsx
@@ -5,6 +5,7 @@ import { Grid, GridItem } from '../grid/grid';
 import axios from 'axios';
 import {
   Actions,
+  Container,
   Fieldset,
   InputField,
   ProgressBar,
@@ -18,14 +19,14 @@ interface CareerFormProps {
   company_id: string;
 }
 
-type FormData = {
+interface FormData {
   first_name: string;
   last_name: string;
   email: string;
   documents: FileList;
   message: string;
   phone?: string;
-};
+}
 
 const API_ENDPOINT = 'https://api.personio.de/recruiting/applicant';
 const SIMPLE_EMAIL_PATTERN = /.+@.+\..+/;
@@ -108,84 +109,86 @@ export const CareerForm: React.FC<CareerFormProps> = (props) => {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit, onError)}>
-      <Fieldset disabled={isSubmitting}>
-        <Grid>
-          {/*First Name*/}
-          <GridItem xs={12} md={6}>
-            <InputField
-              inputRef={register({ required: 'Dein Vorname fehlt' })}
-              error={errors.first_name}
-              name="first_name"
-              placeholder="Vorname"
-            />
-          </GridItem>
+    <Container>
+      <form onSubmit={handleSubmit(onSubmit, onError)}>
+        <Fieldset disabled={isSubmitting}>
+          <Grid nested>
+            {/*First Name*/}
+            <GridItem xs={12} md={6}>
+              <InputField
+                inputRef={register({ required: 'Dein Vorname fehlt' })}
+                error={errors.first_name}
+                name="first_name"
+                placeholder="Vorname"
+              />
+            </GridItem>
 
-          {/*Last Name*/}
-          <GridItem xs={12} md={6}>
-            <InputField
-              inputRef={register({ required: 'Dein Nachname fehlt' })}
-              error={errors.last_name}
-              name="last_name"
-              placeholder="Nachname"
-            />
-          </GridItem>
+            {/*Last Name*/}
+            <GridItem xs={12} md={6}>
+              <InputField
+                inputRef={register({ required: 'Dein Nachname fehlt' })}
+                error={errors.last_name}
+                name="last_name"
+                placeholder="Nachname"
+              />
+            </GridItem>
 
-          {/*E-Mail*/}
-          <GridItem xs={12} md={6}>
-            <InputField
-              inputRef={register({
-                required: 'Deine E-Mail fehlt',
-                pattern: {
-                  value: SIMPLE_EMAIL_PATTERN,
-                  message: `Irgendwas stimmt an dieser E-Mail nicht`,
-                },
-              })}
-              error={errors.email}
-              name="email"
-              placeholder="E-Mail-Adresse"
-            />
-          </GridItem>
+            {/*E-Mail*/}
+            <GridItem xs={12} md={6}>
+              <InputField
+                inputRef={register({
+                  required: 'Deine E-Mail fehlt',
+                  pattern: {
+                    value: SIMPLE_EMAIL_PATTERN,
+                    message: `Irgendwas stimmt an dieser E-Mail nicht`,
+                  },
+                })}
+                error={errors.email}
+                name="email"
+                placeholder="E-Mail-Adresse"
+              />
+            </GridItem>
 
-          {/*CV File */}
-          <GridItem>
-            <InputField
-              inputRef={register({ required: 'Dein CV fehlt' })}
-              error={errors.documents}
-              name="documents"
-              type={'file'}
-              placeholder="E-Mail-Adresse"
-            />
-          </GridItem>
+            {/*CV File */}
+            <GridItem>
+              <InputField
+                inputRef={register({ required: 'Dein CV fehlt' })}
+                error={errors.documents}
+                name="documents"
+                type={'file'}
+                placeholder="E-Mail-Adresse"
+              />
+            </GridItem>
 
-          {/*Cover Letter*/}
-          <GridItem>
-            <TextArea
-              placeholder="Dein Cover Letter"
-              name="message"
-              ref={register({ required: 'Dein Anschreiben fehlt' })}
-              hasError={!!errors.message}
-            />
-            {errors.message && (
-              <ErrorMessage>
-                <span>{errors.message.message}</span>
-              </ErrorMessage>
-            )}
-          </GridItem>
+            {/*Cover Letter*/}
+            <GridItem>
+              <TextArea
+                placeholder="Dein Cover Letter"
+                name="message"
+                ref={register({ required: 'Dein Anschreiben fehlt' })}
+                hasError={!!errors.message}
+              />
+              {errors.message && (
+                <ErrorMessage>
+                  <span>{errors.message.message}</span>
+                </ErrorMessage>
+              )}
+            </GridItem>
 
-          <GridItem>
-            <ProgressBar
-              isSubmitting={isSubmitting}
-              progress={uploadProgress}
-            />
-            <Actions
-              tryAgainFn={tryAgain}
-              isSubmitting={isSubmitting}
-              error={errors.api}
-            />
-          </GridItem>
-        </Grid>
-      </Fieldset>
-    </form>
+            <GridItem>
+              <ProgressBar
+                isSubmitting={isSubmitting}
+                progress={uploadProgress}
+              />
+              <Actions
+                tryAgainFn={tryAgain}
+                isSubmitting={isSubmitting}
+                error={errors.api}
+              />
+            </GridItem>
+          </Grid>
+        </Fieldset>
+      </form>
+    </Container>
   );
 };

--- a/src/components/career-form/career-form.tsx
+++ b/src/components/career-form/career-form.tsx
@@ -5,7 +5,7 @@ import { Grid, GridItem } from '../grid/grid';
 import axios from 'axios';
 import {
   Actions,
-  Container,
+  CareerFormStyled,
   Fieldset,
   InputField,
   ProgressBar,
@@ -109,86 +109,84 @@ export const CareerForm: React.FC<CareerFormProps> = (props) => {
   }
 
   return (
-    <Container>
-      <form onSubmit={handleSubmit(onSubmit, onError)}>
-        <Fieldset disabled={isSubmitting}>
-          <Grid nested>
-            {/*First Name*/}
-            <GridItem xs={12} md={6}>
-              <InputField
-                inputRef={register({ required: 'Dein Vorname fehlt' })}
-                error={errors.first_name}
-                name="first_name"
-                placeholder="Vorname"
-              />
-            </GridItem>
+    <CareerFormStyled onSubmit={handleSubmit(onSubmit, onError)}>
+      <Fieldset disabled={isSubmitting}>
+        <Grid nested>
+          {/*First Name*/}
+          <GridItem xs={12} md={6}>
+            <InputField
+              inputRef={register({ required: 'Dein Vorname fehlt' })}
+              error={errors.first_name}
+              name="first_name"
+              placeholder="Vorname"
+            />
+          </GridItem>
 
-            {/*Last Name*/}
-            <GridItem xs={12} md={6}>
-              <InputField
-                inputRef={register({ required: 'Dein Nachname fehlt' })}
-                error={errors.last_name}
-                name="last_name"
-                placeholder="Nachname"
-              />
-            </GridItem>
+          {/*Last Name*/}
+          <GridItem xs={12} md={6}>
+            <InputField
+              inputRef={register({ required: 'Dein Nachname fehlt' })}
+              error={errors.last_name}
+              name="last_name"
+              placeholder="Nachname"
+            />
+          </GridItem>
 
-            {/*E-Mail*/}
-            <GridItem xs={12} md={6}>
-              <InputField
-                inputRef={register({
-                  required: 'Deine E-Mail fehlt',
-                  pattern: {
-                    value: SIMPLE_EMAIL_PATTERN,
-                    message: `Irgendwas stimmt an dieser E-Mail nicht`,
-                  },
-                })}
-                error={errors.email}
-                name="email"
-                placeholder="E-Mail-Adresse"
-              />
-            </GridItem>
+          {/*E-Mail*/}
+          <GridItem xs={12} md={6}>
+            <InputField
+              inputRef={register({
+                required: 'Deine E-Mail fehlt',
+                pattern: {
+                  value: SIMPLE_EMAIL_PATTERN,
+                  message: `Irgendwas stimmt an dieser E-Mail nicht`,
+                },
+              })}
+              error={errors.email}
+              name="email"
+              placeholder="E-Mail-Adresse"
+            />
+          </GridItem>
 
-            {/*CV File */}
-            <GridItem>
-              <InputField
-                inputRef={register({ required: 'Dein CV fehlt' })}
-                error={errors.documents}
-                name="documents"
-                type={'file'}
-                placeholder="E-Mail-Adresse"
-              />
-            </GridItem>
+          {/*CV File */}
+          <GridItem>
+            <InputField
+              inputRef={register({ required: 'Dein CV fehlt' })}
+              error={errors.documents}
+              name="documents"
+              type={'file'}
+              placeholder="E-Mail-Adresse"
+            />
+          </GridItem>
 
-            {/*Cover Letter*/}
-            <GridItem>
-              <TextArea
-                placeholder="Dein Cover Letter"
-                name="message"
-                ref={register({ required: 'Dein Anschreiben fehlt' })}
-                hasError={!!errors.message}
-              />
-              {errors.message && (
-                <ErrorMessage>
-                  <span>{errors.message.message}</span>
-                </ErrorMessage>
-              )}
-            </GridItem>
+          {/*Cover Letter*/}
+          <GridItem>
+            <TextArea
+              placeholder="Dein Cover Letter"
+              name="message"
+              ref={register({ required: 'Dein Anschreiben fehlt' })}
+              hasError={!!errors.message}
+            />
+            {errors.message && (
+              <ErrorMessage>
+                <span>{errors.message.message}</span>
+              </ErrorMessage>
+            )}
+          </GridItem>
 
-            <GridItem>
-              <ProgressBar
-                isSubmitting={isSubmitting}
-                progress={uploadProgress}
-              />
-              <Actions
-                tryAgainFn={tryAgain}
-                isSubmitting={isSubmitting}
-                error={errors.api}
-              />
-            </GridItem>
-          </Grid>
-        </Fieldset>
-      </form>
-    </Container>
+          <GridItem>
+            <ProgressBar
+              isSubmitting={isSubmitting}
+              progress={uploadProgress}
+            />
+            <Actions
+              tryAgainFn={tryAgain}
+              isSubmitting={isSubmitting}
+              error={errors.api}
+            />
+          </GridItem>
+        </Grid>
+      </Fieldset>
+    </CareerFormStyled>
   );
 };

--- a/src/components/form/contact.tsx
+++ b/src/components/form/contact.tsx
@@ -1,145 +1,22 @@
 import React, { ChangeEventHandler, FormEventHandler, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import styled from 'styled-components';
-import { up } from '../breakpoint/breakpoint';
 import { CheckmarkIcon } from '../icons/buttons-icons/checkmark';
 import { RightArrowIcon } from '../icons/buttons-icons/right-arrow';
-import { Text } from '../typography/typography';
+import {
+  ButtonText,
+  ErrorMessage,
+  ErrorMessageSend,
+  Input,
+  InputContainer,
+  InputWrapper,
+  RequestStatusMessage,
+  SendButton,
+  SentButton,
+  TextArea,
+} from './controls';
 
 //https://www.codegrepper.com/code-examples/basic/form+validation+in+gatsby
 const IS_EMAIL_REGEX = /^(([^<>()\]\\.,;:\s@"]+(\.[^<>()\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-const InputContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-
-  ${up('md')} {
-    flex-direction: row;
-  }
-`;
-
-const InputWrapper = styled.div`
-  width: 100%;
-  margin-bottom: 24px;
-
-  &:not(:last-of-type) {
-    margin-right: 24px;
-
-    ${up('md')} {
-      margin-right: 24px;
-    }
-  }
-`;
-
-interface ValidationProps {
-  hasError?: boolean;
-}
-
-const Input = styled.input<ValidationProps>`
-  width: 100%;
-  padding: 19px 16px;
-
-  font-size: 16px;
-  line-height: 110%;
-
-  border-radius: 4px;
-  border: 0;
-  background: #f5f6f7;
-
-  &:not(:last-of-type) {
-    margin-right: 0;
-
-    ${up('md')} {
-      margin-right: 24px;
-      margin-bottom: 0;
-    }
-  }
-
-  ${({ hasError }) =>
-    hasError &&
-    `
-    background: #f8cdd5;
-    color: #dc052d;
-    ::placeholder {
-      color: #dc052d;
-      opacity: 1;
-    }
-  `}
-`;
-
-const TextArea = styled.textarea<ValidationProps>`
-  height: 190px;
-  width: 100%;
-  padding: 19px 16px;
-
-  font-size: 16px;
-  line-height: 110%;
-
-  border-radius: 4px;
-  border: 0;
-  background: #f5f6f7;
-
-  resize: vertical;
-
-  ${({ hasError }) =>
-    hasError &&
-    `
-  background: #f8cdd5;
-  ::placeholder {
-    color: #dc052d;
-    opacity: 1;
-  }
-`}
-`;
-
-const Button = styled.button`
-  margin-top: 40px;
-  cursor: pointer;
-  padding: 13px 18px;
-
-  font-size: 20px;
-  font-weight: bold;
-  text-align: left;
-  line-height: 110%;
-
-  border-radius: 28px;
-  border: 0;
-  width: 147px;
-`;
-
-const ButtonText = styled.span`
-  margin-right: 40px;
-`;
-
-const SendButton = styled(Button)`
-  color: #ffffff;
-  background: #668cff;
-`;
-
-const SentButton = styled(Button)`
-  color: #202840;
-  background: #75f0c7;
-`;
-
-const RequestStatusMessage = styled(Text)`
-  display: inline-block;
-  margin-left: 24px;
-  color: #668cff;
-  font-size: 14px;
-`;
-
-const ErrorMessage = styled.p`
-  color: #dc052d;
-  font-size: 14px;
-  margin-top: 8px;
-  margin-bottom: 0;
-`;
-
-const ErrorMessageSend = styled(ErrorMessage)`
-  display: inline-block;
-  margin-left: 24px;
-`;
 
 type RequestStatus = 'pending' | 'success' | 'error';
 

--- a/src/components/form/controls.tsx
+++ b/src/components/form/controls.tsx
@@ -1,0 +1,143 @@
+import styled from 'styled-components';
+import { up } from '../breakpoint/breakpoint';
+import { Text } from '../typography/typography';
+
+interface ValidationProps {
+  hasError?: boolean;
+}
+
+export const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  ${up('md')} {
+    flex-direction: row;
+  }
+`;
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 24px;
+
+  &:not(:last-of-type) {
+    margin-right: 24px;
+
+    ${up('md')} {
+      margin-right: 24px;
+    }
+  }
+`;
+
+export const Input = styled.input<ValidationProps>`
+  width: 100%;
+  padding: 19px 16px;
+
+  font-size: 16px;
+  line-height: 110%;
+
+  border-radius: 4px;
+  border: 0;
+  background: #f5f6f7;
+
+  &:not(:last-of-type) {
+    margin-right: 0;
+
+    ${up('md')} {
+      margin-right: 24px;
+      margin-bottom: 0;
+    }
+  }
+
+  ${({ hasError }) =>
+    hasError &&
+    `
+    background: #f8cdd5;
+    color: #dc052d;
+    ::placeholder {
+      color: #dc052d;
+      opacity: 1;
+    }
+  `}
+`;
+
+export const TextArea = styled.textarea<ValidationProps>`
+  height: 190px;
+  width: 100%;
+  padding: 19px 16px;
+
+  font-size: 16px;
+  line-height: 110%;
+
+  border-radius: 4px;
+  border: 0;
+  background: #f5f6f7;
+
+  resize: vertical;
+
+  ${({ hasError }) =>
+    hasError &&
+    `
+  background: #f8cdd5;
+  ::placeholder {
+    color: #dc052d;
+    opacity: 1;
+  }
+`}
+`;
+
+export const Button = styled.button`
+  margin-top: 40px;
+  cursor: pointer;
+  padding: 13px 18px;
+
+  font-size: 20px;
+  font-weight: bold;
+  text-align: left;
+  line-height: 110%;
+
+  border-radius: 28px;
+  border: 0;
+  width: 147px;
+`;
+
+export const ButtonText = styled.span`
+  margin-right: 40px;
+`;
+
+export const SendButton = styled(Button)`
+  color: #ffffff;
+  background: #668cff;
+
+  ${({ disabled }) =>
+    disabled &&
+    `
+    background: #aaaaaa;
+    cursor: wait
+`}
+`;
+
+export const SentButton = styled(Button)`
+  cursor: default;
+  color: #202840;
+  background: #75f0c7;
+`;
+
+export const RequestStatusMessage = styled(Text)`
+  display: inline-block;
+  margin-left: 24px;
+  color: #668cff;
+  font-size: 14px;
+`;
+
+export const ErrorMessage = styled.p`
+  color: #dc052d;
+  font-size: 14px;
+  margin-top: 8px;
+  margin-bottom: 0;
+`;
+
+export const ErrorMessageSend = styled(ErrorMessage)`
+  display: inline-block;
+  margin-left: 24px;
+`;

--- a/src/components/grid/grid.tsx
+++ b/src/components/grid/grid.tsx
@@ -9,6 +9,7 @@ export const GRID_GAP_MOBILE: CSSProp = '16px';
 interface GridProps {
   disableGap?: boolean;
   center?: boolean;
+  nested?: boolean;
 }
 
 /**
@@ -21,7 +22,8 @@ export const Grid = styled.div<GridProps>`
   grid-template-columns: repeat(12, 1fr);
 
   grid-column-gap: ${(props) => (props.disableGap ? 0 : GRID_GAP_MOBILE)};
-  padding: 0 ${(props) => (props.disableGap ? 0 : GRID_GAP_MOBILE)}; // outer gap
+  padding: 0
+    ${(props) => (props.disableGap || props.nested ? 0 : GRID_GAP_MOBILE)}; // outer gap
 
   max-width: ${(props) => props.theme.maxWidth};
 
@@ -35,7 +37,8 @@ export const Grid = styled.div<GridProps>`
 
   ${up('md')} {
     grid-column-gap: ${(props) => (props.disableGap ? 0 : GRID_GAP_DESKTOP)};
-    padding: 0 ${(props) => (props.disableGap ? 0 : GRID_GAP_DESKTOP)}; // outer gap
+    padding: 0
+      ${(props) => (props.disableGap || props.nested ? 0 : GRID_GAP_DESKTOP)}; // outer gap
   }
 `;
 

--- a/src/components/navigation/__snapshots__/navigation.test.tsx.snap
+++ b/src/components/navigation/__snapshots__/navigation.test.tsx.snap
@@ -9,7 +9,7 @@ Object {
         class="sc-iBPRYJ cdUVjp"
       >
         <div
-          class="sc-bdfBwQ gXQOMz"
+          class="sc-bdfBwQ jtOzOH"
         >
           <div
             class="sc-gsTCUz hfpEbi"
@@ -198,7 +198,7 @@ Object {
       class="sc-iBPRYJ cdUVjp"
     >
       <div
-        class="sc-bdfBwQ gXQOMz"
+        class="sc-bdfBwQ jtOzOH"
       >
         <div
           class="sc-gsTCUz hfpEbi"

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -29,6 +29,7 @@ const ServicesPage: React.FC = () => {
         <GridItem>
           <PageTitle>Leistungen</PageTitle>
         </GridItem>
+
         <GridItem xs={12} md={8}>
           <LargeText as={'h2'}>
             Satellytes – das sind ausschließlich leidenschaftliche

--- a/src/templates/career-details.tsx
+++ b/src/templates/career-details.tsx
@@ -104,7 +104,7 @@ const CareerPage = ({ pageContext }: CareerPageProps): JSX.Element => {
             company_id="41230"
             recruiting_channel_id="329206"
             access_token="89b2acfa3a239b75c7d6"
-            job_position_id={pageContext.position.id}
+            job_position_id={pageContext.position.id + ''}
           />
         </GridItem>
       </Grid>

--- a/src/templates/career-details.tsx
+++ b/src/templates/career-details.tsx
@@ -6,7 +6,8 @@ import { Grid, GridItem } from '../components/grid/grid';
 import { PersonioJobPosition } from './career';
 import styled from 'styled-components';
 import { up } from '../components/breakpoint/breakpoint';
-import { TextTitle } from '../components/typography/typography';
+import { LargeText, TextTitle } from '../components/typography/typography';
+import { CareerForm } from '../components/career-form/career-form';
 
 const PERSONIO_SHORT_DESCRIPTION_NAME = 'Kurzbeschreibung';
 
@@ -95,6 +96,16 @@ const CareerPage = ({ pageContext }: CareerPageProps): JSX.Element => {
               </div>
             );
           })}
+        </GridItem>
+
+        <GridItem xs={12} md={8}>
+          <SectionTitle>Bewirb dich jetzt</SectionTitle>
+          <CareerForm
+            company_id="41230"
+            recruiting_channel_id="329206"
+            access_token="89b2acfa3a239b75c7d6"
+            job_position_id={pageContext.position.id}
+          />
         </GridItem>
       </Grid>
     </Layout>

--- a/src/templates/career.tsx
+++ b/src/templates/career.tsx
@@ -47,7 +47,7 @@ interface PersonioJobNameValue {
 }
 
 export interface PersonioJobPosition {
-  id: number;
+  id: string;
   office: string;
   department: string;
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "noUnusedLocals": false,
     "skipLibCheck": true,
-    "allowJs": true
+    "allowJs": true,
+    "noImplicitAny": false
   },
   "exclude": ["node_modules", "public", ".cache", "cypress", "gatsby-ssr.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11722,6 +11722,13 @@ pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+polished@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.1.tgz#40442cc973348e466f2918cdf647531bb6c29bfb"
+  integrity sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"


### PR DESCRIPTION
This is based on the changes in #65 and therefore include those changes too. Let's review the other PR first. You can still checkout the preview though and give some feedback.

Included:
+ Use the excellent `react-form-hooks` ✨
+ I decided to use axios in order to get easily access to the upload progress and a better error handling (compared to fetch). We can also offer a cancellation while the upload is running with axios through their cancelation token.
+ I moved the controls in the existing contact form into a separate file to reuse some of them.
+ Form expects some props around the API connection (company id & access token) plus the job id that is different per job.
+ Collected some components outside of the form itself to make it a little bit more readable. It still feels like a mess and I wonder if this is react as is or if I could improve some parts.

+ Form Behavior:
   + Validation only after click on submit
   + Display a progress bar for the running upload
   + Disable the form while submitting
   + Hide the form when completed and display a proper message
   + Everything is German but we should think about translating it soon to make it more accessible to non-German folks.
   + When an error happens on the API side the form is unlocked again and a `try again` button is displayed. Click it to reveal the submit button again once you have read the error message.


