### PR TITLE
feat: improve font loading

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,5 +72,8 @@ module.exports = {
         exclude: ['/imprint', '/data-privacy', '/blog/**'],
       },
     },
+    {
+      resolve: `gatsby-plugin-netlify`,
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gatsby-background-image": "^1.5.3",
     "gatsby-image": "3.4.0",
     "gatsby-plugin-manifest": "3.4.0",
+    "gatsby-plugin-netlify": "^3.4.0",
     "gatsby-plugin-react-helmet": "4.4.0",
     "gatsby-plugin-robots-txt": "^1.5.6",
     "gatsby-plugin-sharp": "3.4.1",

--- a/src/components/layout/fonts/fonts.css
+++ b/src/components/layout/fonts/fonts.css
@@ -7,7 +7,7 @@
     font-family: 'CocoGothic';
     font-style: normal;
     font-weight: 400;
-    font-display: block;
+    font-display: auto;
     src: local('CocoGothic'),
     url("CocoGothic.woff2") format('woff2'),
     url("CocoGothic.woff") format('woff'),
@@ -19,7 +19,7 @@
     font-family: 'CocoGothic';
     font-style: italic;
     font-weight: 400;
-    font-display: block;
+    font-display: auto;
     src: local('CocoGothic Italic'),
     url("CocoGothic-Italic.woff2") format('woff2'),
     url("CocoGothic-Italic.woff") format('woff'),
@@ -31,7 +31,7 @@
     font-family: 'CocoGothic';
     font-style: normal;
     font-weight: 700;
-    font-display: block;
+    font-display: auto;
     src: local('CocoGothic Bold'),
     url("CocoGothic-Bold.woff2") format('woff2'),
     url("CocoGothic-Bold.woff") format('woff'),

--- a/src/components/layout/fonts/fonts.css
+++ b/src/components/layout/fonts/fonts.css
@@ -7,7 +7,7 @@
     font-family: 'CocoGothic';
     font-style: normal;
     font-weight: 400;
-    font-display: swap;
+    font-display: block;
     src: local('CocoGothic'),
     url("CocoGothic.woff2") format('woff2'),
     url("CocoGothic.woff") format('woff'),
@@ -19,7 +19,7 @@
     font-family: 'CocoGothic';
     font-style: italic;
     font-weight: 400;
-    font-display: swap;
+    font-display: block;
     src: local('CocoGothic Italic'),
     url("CocoGothic-Italic.woff2") format('woff2'),
     url("CocoGothic-Italic.woff") format('woff'),
@@ -31,7 +31,7 @@
     font-family: 'CocoGothic';
     font-style: normal;
     font-weight: 700;
-    font-display: swap;
+    font-display: block;
     src: local('CocoGothic Bold'),
     url("CocoGothic-Bold.woff2") format('woff2'),
     url("CocoGothic-Bold.woff") format('woff'),

--- a/src/components/teasers/block-teaser.tsx
+++ b/src/components/teasers/block-teaser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { up } from '../breakpoint/breakpoint';
-import { Link, LinkButton } from '../links/links';
+import { LinkButton } from '../links/links';
 
 const Teaser = styled.div``;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,6 +3980,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -5027,7 +5035,7 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^4.0.0, deepmerge@^4.2.2:
+deepmerge@^4.0, deepmerge@^4.0.0, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -6876,6 +6884,17 @@ gatsby-plugin-manifest@3.4.0:
     gatsby-plugin-utils "^1.4.0"
     semver "^7.3.2"
     sharp "^0.28.0"
+
+gatsby-plugin-netlify@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-netlify/-/gatsby-plugin-netlify-3.4.0.tgz#492e002acfe11bf2aad78ff6d130f3855a8640ca"
+  integrity sha512-11BedkoJpwR3m9LejpjsSyf4tcbUJxB07X4ho/ohD2FUZdXzClL3Bi4guVwRP4xwYzzQoMvGnQA83BZk0DEkeA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    fs-extra "^8.1.0"
+    kebab-hash "^0.1.2"
+    lodash "^4.17.21"
+    webpack-assets-manifest "^5.0.5"
 
 gatsby-plugin-page-creator@^3.4.1:
   version "3.4.1"
@@ -9759,6 +9778,13 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+kebab-hash@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/kebab-hash/-/kebab-hash-0.1.2.tgz#dfb7949ba34d8e70114ea7d83e266e5e2a4abaac"
+  integrity sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==
+  dependencies:
+    lodash.kebabcase "^4.1.1"
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -9986,6 +10012,13 @@ lock@^1.0.0:
   resolved "https://registry.yarnpkg.com/lock/-/lock-1.1.0.tgz#53157499d1653b136ca66451071fca615703fa55"
   integrity sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU=
 
+lockfile@^1.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
+  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
+  dependencies:
+    signal-exit "^3.0.2"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -10026,15 +10059,25 @@ lodash.foreach@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-lodash.get@^4:
+lodash.get@^4, lodash.get@^4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.has@^4.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.map@^4.6.0:
   version "4.6.0"
@@ -13620,7 +13663,7 @@ schema-utils@^2.6.5:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-schema-utils@^3.0.0:
+schema-utils@^3.0, schema-utils@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
   integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
@@ -14739,7 +14782,7 @@ tapable@^1.0.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.1.1, tapable@^2.2.0:
+tapable@^2.0, tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
@@ -15801,6 +15844,19 @@ webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+
+webpack-assets-manifest@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/webpack-assets-manifest/-/webpack-assets-manifest-5.0.6.tgz#1fe7baf9b57f2d28ff09fcaef3d678cc15912b88"
+  integrity sha512-CW94ylPHurZTmxnYajSFA8763Cv/QFIKNgBwqBLaIOnBjH1EbDUAf8Eq1/i+o8qaKyKXJ3aX7r4/jtpXD88ldg==
+  dependencies:
+    chalk "^4.0"
+    deepmerge "^4.0"
+    lockfile "^1.0"
+    lodash.get "^4.0"
+    lodash.has "^4.0"
+    schema-utils "^3.0"
+    tapable "^2.0"
 
 webpack-dev-middleware@^3.7.2:
   version "3.7.3"


### PR DESCRIPTION
This PR started with a simple fix and ended in a detailed analysis 😄 

The changes of this PR should hopefully fix the problem:
- correct caching headers to show the font immediately when reloading or revisiting the page
- using `font-display: auto` instead of `swap` to let the browser decide which font to show (for the first visit when the font is not cached yet)

## Current situation

1. We already [preload](https://web.dev/optimize-webfont-loading/#preload-your-webfont-resources) the `normal` and `bold` font with highest priority (not `italic`, as this font is only used on some special occasions). It also gets cached correctly: 
![image](https://user-images.githubusercontent.com/7814926/117112711-c3adbc80-ad89-11eb-9c4d-07026ca51b08.png)
2. If you run `yarn build` on localhost and then `yarn serve`, you will see the correct font immediately. This is the case for both `font-display: swap` and `font-display: block`. 

What is the difference between Prod and Localhost?

It's the waiting time for the response:
On Production, the browser has to wait 170ms for the response
![image](https://user-images.githubusercontent.com/7814926/117114971-c4941d80-ad8c-11eb-9cbe-dee6b782898d.png)
Caching header: `public, max-age=0, must-revalidate`

On localhost, it's only 12ms
![image](https://user-images.githubusercontent.com/7814926/117115041-dbd30b00-ad8c-11eb-9ecd-f9094a83ae4b.png)
Caching header: `Cache-Control: public, max-age=0`

## Possible solutions

**improve caching headers**
Netlify sets the `must-revalidate` header. This header means, that the browser asks the server first if the resource has changed before it is used (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#revalidation_and_reloading). As the font never changes, we can omnit this header.

Correct caching header for fonts:
`cache-control: public, max-age=31536000, immutable` ([Gatsby Docs](https://www.gatsbyjs.com/docs/caching/#static-files))

-> will do

**better fallback font**
We can improve our fallback font with https://meowni.ca/font-style-matcher/ 
This will not remove the flicker, but reduces it to a minimum.

- could do: this would improve the font swapping for first time visitors. let's see how `font-display: auto` will work and if this is still necessary

**[omni-font-loader plugin](https://github.com/codeAdrian/gatsby-omni-font-loader)**
Using a different font loading mechanism won't make any difference. The font is already loaded with highest priority.

-> won't do: doesn't solve the problem

**font-display block**
Using `font-display: block` will make the page still flicker, as the font is not displayed initially (but all other elements). It's just a different flicker as it is right now.

> This PR introduces the `font-display: block`. You can see the behaviour in the preview. Keep in mind that the preview environment disables caching in the browser

-> won't do: doesn't solve the problem

## Changing the Netlify headers

Netlify headers can be customized within the `_headers` file: https://docs.netlify.com/routing/headers/
There is also a Gatsby Netlify plugin which will add some all the headers we need out of the box: https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify

**Result**
Font is in the static folder. Marking those files as `immutable` should make them instantly available in the browser.
![image](https://user-images.githubusercontent.com/7814926/117119436-58b4b380-ad92-11eb-91e1-a8e80fa4e245.png)
