### PR TITLE
fix: share image url with base url plus correct slash separator

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,7 +21,7 @@ const extractGatsbyCloudPreviewUrl = () => {
     '',
   );
 
-  return `https://${DOMAIN_NAME}-${formattedBranchName}.gtsb.io/`;
+  return `https://${DOMAIN_NAME}-${formattedBranchName}.gtsb.io`;
 };
 
 const BASE_URL = extractGatsbyCloudPreviewUrl() || 'http://localhost:8000';

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,7 @@ exports.onCreateNode = ({ node, getNode, actions, graphql }, options) => {
       lower: true,
     })}.jpg`;
     const outputFile = path.join('public', fileName);
-    const publicUrl = `${siteMetadata.siteUrl}${fileName}`;
+    const publicUrl = `${siteMetadata.siteUrl}/${fileName}`;
 
     generateCard({ title: post.title }, outputFile).then((filename) => {
       createNodeField({
@@ -110,7 +110,7 @@ const createCareerPages = async ({ actions }) => {
       lower: true,
     })}.jpg`;
     const outputFile = path.join('public', fileName);
-    const publicUrl = `${siteMetadata.siteUrl}${fileName}`;
+    const publicUrl = `${siteMetadata.siteUrl}/${fileName}`;
 
     generateCard({ title: position.name }, outputFile);
 


### PR DESCRIPTION
hotfix because the share images did not contain the correct path. A `/` was missing. I wanted to fix the env `GATBSY_BASE_URL` to append that slash but then I decided to strip the slash from the staging urls (that's why it worked in the past PR). Now we have `BASE_URL + '/' + IMAGE_URL` instead of `BASE_URL + IMAGE_URL`. I'm always undecided what to use 🤓

I verified that it will work on `main` by shortcutting `extractGatsbyCloudPreviewUrl()` to return `http://satellytes.com`.