### PR TITLE
feat: update all dependencies on a regular schedule

### DIFF
--- a/.github/workflows/scheduled-dependency-update.yml
+++ b/.github/workflows/scheduled-dependency-update.yml
@@ -1,0 +1,33 @@
+name: Scheduled Dependency Update
+
+on:
+  # run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  # every monday at 02:00
+  schedule:
+    - cron: '0 2 * * 1'
+
+jobs:
+  dependency-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Upgrade dependencies
+        run: yarn upgrade --latest
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          branch: chore-dependency-update
+          delete-branch: true
+          title: "chore: dependency update"
+          commit-message: "chore: dependency update"
+          body: |
+            This PR was automatically created.
+            - all dependencies are updated
+            - this PR will be created every monday at 2am and force pushed


### PR DESCRIPTION
It's time to automate some housekeeping: Updating dependencies 🧹

This Github Action will update all our dependencies to their latest version, commit it to a new branch and open a pull request. This again will trigger the Gatsby Cloud build, so all we have to do is to click on "Merge" if the build is successful.

The Github Action will run every monday at 2am.