### PR TITLE
feat: improve google indexing

### DIFF
--- a/blog-posts/angular-inject-the-injector.md
+++ b/blog-posts/angular-inject-the-injector.md
@@ -1,5 +1,5 @@
 ---
-path: "/blog/angular-inject-the-injector"
+path: "/blog/angular-inject-the-injector/"
 date: "2021-06-08"
 title: "The \"Inject the Injector\" pattern"
 featuredImage: images/georgios-kaleadis-aBTfTMsOCOI-unsplash.jpg 

--- a/blog-posts/angular-workshop-2019.md
+++ b/blog-posts/angular-workshop-2019.md
@@ -1,5 +1,5 @@
 ---
-path: "/blog/angular-workshop-kaiserx-allianz-2018"
+path: "/blog/angular-workshop-kaiserx-allianz-2018/"
 date: "2018-12-01"
 title: Angular Advanced Workshop (2018)
 featuredImage: images/angular.png

--- a/blog-posts/howto-blog-post.md
+++ b/blog-posts/howto-blog-post.md
@@ -1,5 +1,5 @@
 ---
-path: "/blog/howto-blog-post"
+path: "/blog/howto-blog-post/"
 date: "2021-05-01"
 title: "How to do a blog post"
 featuredImage: images/space.jpg

--- a/blog-posts/monorepo-code-owner.md
+++ b/blog-posts/monorepo-code-owner.md
@@ -1,5 +1,5 @@
 ---
-path: "/blog/monorepo-codeowner-github-enterprise"
+path: "/blog/monorepo-codeowner-github-enterprise/"
 date: "2021-07-09"
 title: Every big monorepo needs the CODEOWNERS feature
 featuredImage: images/chang-duong-Sj0iMtq_Z4w-unsplash.jpg

--- a/blog-posts/typescript-ast-type-checker.md
+++ b/blog-posts/typescript-ast-type-checker.md
@@ -1,5 +1,5 @@
 ---
-path: "/blog/typescript-ast-type-checker"
+path: "/blog/typescript-ast-type-checker/"
 date: "2021-06-18"
 title: "Going beyond the Abstract Syntax Tree (AST) with the TypeScript Type Checker"
 shortSummary: How to analyze a typescript file beyond the Abstract Syntax Tree (AST) with the TS type checking utility "checker.ts"

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -117,6 +117,12 @@ module.exports = {
     'gatsby-plugin-styled-components',
     'gatsby-plugin-typescript',
     {
+      resolve: 'gatsby-plugin-canonical-urls',
+      options: {
+        siteUrl: 'https://satellytes.com',
+      },
+    },
+    {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
         host: 'https://satellytes.com',
@@ -135,8 +141,13 @@ module.exports = {
       options: {
         excludes: ['/imprint', '/data-privacy'],
         resolvePagePath: ({ path }) => {
-          // trailing slashes are direct links without a redirect
-          return path.endsWith('/') ? path : `${path}/`;
+          if (!path.endsWith('/')) {
+            console.warn(
+              'Path of the page does not end with a slash! For SEO reasons all paths should end with a slash:',
+              path,
+            );
+          }
+          return path;
         },
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -134,6 +134,10 @@ module.exports = {
       resolve: `gatsby-plugin-sitemap`,
       options: {
         excludes: ['/imprint', '/data-privacy'],
+        resolvePagePath: ({ path }) => {
+          // trailing slashes are direct links without a redirect
+          return path.endsWith('/') ? path : `${path}/`;
+        },
       },
     },
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -114,7 +114,7 @@ const createCareerPages = async ({ actions }) => {
     generateCard({ title: position.name }, outputFile);
 
     createPage({
-      path: position.satellytesPath,
+      path: appendTrailingSlash(position.satellytesPath),
       component: CAREER_DETAILS_TEMPLATE_PATH,
       context: {
         position,
@@ -124,7 +124,7 @@ const createCareerPages = async ({ actions }) => {
   });
 
   createPage({
-    path: '/career',
+    path: '/career/',
     component: CAREER_TEMPLATE_PATH,
     context: {
       positions: positions,
@@ -158,7 +158,7 @@ const createBlogPages = async ({ actions, reporter, graphql }) => {
   // create a page for each markdown file
   markdownBlogPages.data.allMarkdownRemark.nodes.forEach((node) => {
     createPage({
-      path: node.frontmatter.path,
+      path: appendTrailingSlash(node.frontmatter.path),
       component: BLOG_POST_TEMPLATE_PATH,
       context: {},
     });
@@ -187,7 +187,7 @@ const createClientPages = async ({ actions, reporter, graphql }) => {
 
   clientPages.data.allClientsJson.nodes.forEach((node) => {
     createPage({
-      path: node.path,
+      path: appendTrailingSlash(node.path),
       component: CLIENT_TEMPLATE_PATH,
       context: { linkToThePage: node.path },
     });
@@ -213,4 +213,8 @@ exports.onCreateWebpackConfig = function (_ref) {
       },
     });
   }
+};
+
+const appendTrailingSlash = (path) => {
+  return path.endsWith('/') ? path : `${path}/`;
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gatsby": "3.9.1",
     "gatsby-background-image": "^1.5.3",
     "gatsby-image": "3.9.0",
+    "gatsby-plugin-canonical-urls": "^3.9.0",
     "gatsby-plugin-catch-links": "^3.9.0",
     "gatsby-plugin-image": "^1.9.0",
     "gatsby-plugin-manifest": "3.9.0",

--- a/src/components/cards/blog-card.test.tsx
+++ b/src/components/cards/blog-card.test.tsx
@@ -6,7 +6,7 @@ import { BlogCard } from './blog-card';
 const data = {
   title: 'card title',
   text: 'text',
-  link: '/link',
+  link: '/link/',
   placeholderImage: {
     aspectRatio: NaN,
     src: '',

--- a/src/components/cards/card.test.tsx
+++ b/src/components/cards/card.test.tsx
@@ -6,7 +6,7 @@ import { Card } from './card';
 const data = {
   title: 'card title',
   text: 'text',
-  link: '/link',
+  link: '/link/',
 };
 
 describe('Card', () => {

--- a/src/components/client-list/client-list.test.tsx
+++ b/src/components/client-list/client-list.test.tsx
@@ -9,7 +9,7 @@ const testClients = [
   {
     name: 'client name',
     start: '2020-04-30',
-    path: '/clients/client1',
+    path: '/clients/client1/',
   },
 ];
 

--- a/src/components/links/links.tsx
+++ b/src/components/links/links.tsx
@@ -42,9 +42,18 @@ export const Link = (props: LinkProps): JSX.Element => {
    */
   const isAnchorLink = to.startsWith('#');
 
+  /**
+   * it seems that using consistent '/' at the end of internal links is better
+   * for SEO as it prevents the redirect from non-slash to slash. it also aligns
+   * it with the sitemap.xml
+   *
+   * - https://github.com/gatsbyjs/gatsby/discussions/27889
+   */
+  const toWithSlash = to.endsWith('/') ? to : `${to}/`;
+
   return (
     <InternalLink
-      to={to}
+      to={toWithSlash}
       className={isAnchorLink ? undefined : className}
       {...rest}
     >

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -12,6 +12,7 @@ interface SeoProps {
   lang?: string;
   imageUrl?: string;
   siteType?: string;
+  noIndex?: boolean;
 }
 
 const SEO: React.FC<SeoProps> = ({
@@ -20,6 +21,7 @@ const SEO: React.FC<SeoProps> = ({
   title,
   imageUrl,
   siteType,
+  noIndex,
 }) => {
   const { site } = useStaticQuery(
     graphql`
@@ -76,6 +78,8 @@ const SEO: React.FC<SeoProps> = ({
 
       {/* -- Xing --*/}
       <meta property="og:site_name" content={title} />
+
+      {noIndex && <meta name="robots" content="noindex" />}
 
       {/*
        * All fonts that are linked with a preload are getting loaded before any

--- a/src/pages/data-privacy.tsx
+++ b/src/pages/data-privacy.tsx
@@ -27,6 +27,7 @@ const DataPrivacyPage: React.FC = () => {
       <SEO
         title="Datenschutz | Satellytes"
         description="Information über die Erhebung personenbezogener Daten"
+        noIndex={true}
       />
       <Grid>
         <GridItem>

--- a/src/pages/imprint.tsx
+++ b/src/pages/imprint.tsx
@@ -34,6 +34,7 @@ const ImprintPage: React.FC = () => {
       <SEO
         title="Impressum | Satellytes"
         description="Pflichtangaben nach § 5 Telemediengesetz/Impressum"
+        noIndex={true}
       />
       <Grid>
         <GridItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6773,6 +6773,13 @@ gatsby-page-utils@^1.9.0:
     lodash "^4.17.21"
     micromatch "^4.0.2"
 
+gatsby-plugin-canonical-urls@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-canonical-urls/-/gatsby-plugin-canonical-urls-3.9.0.tgz#5315d64eb797ac776a2c696cca6c1f33a6b6fdb3"
+  integrity sha512-MrzMLiomtIveF6amfvSFBMJfiqnBbwECu9jWrNK9JRFThAEp7f45GhL07atylzgqFwNkg7DJolfnilxOU4my5w==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+
 gatsby-plugin-catch-links@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-3.9.0.tgz#b1cefce8b7254b8690b135f17dca4e32d6a0eea8"


### PR DESCRIPTION
I checked out Google Search Console and found out that we have a bunch of pages that are either not crawled correctly or marked as duplicate content. 

One problem is that amount of link at wich our content can be reach. In worst case, we have 4 different URLs that all point to the same content:

- `http` redirects to `https`
- `www` redirect to an URL without `wwww`
- missing trailing `/` will redirect to `/`

<img width="1283" alt="Screenshot 2021-07-12 at 08 31 11" src="https://user-images.githubusercontent.com/7814926/125241391-a813e480-e2eb-11eb-8302-439db6e96e37.png">


1. For performance reasons, it's best to always point to the URL that doesn't need a redirect. That's why I made sure that all links in the `sitemap.xml` and also all internal links have a trailing slash. This makes all internal links consistent, which is also recommended by the documentation https://developers.google.com/search/docs/advanced/guidelines/duplicate-content

2. Our old `https://satellytes.com/sitemap.xml` was still served, although it's not part of the output folder anymore. It turn out the Gatsby Cloud still adds the root `sitemap.xml`. I started a clean build an hope that it gets removed. Super strange, as this file shouldn't be generated anymore since weeks. Edit: It's gone now.

3. I'm not sure about canonical URLs. The Google Search Console still lists some `www.` URLs, but they all redirect with a 301 to the original file. Due to the documentation this shouldn't be a problem anymore: https://developers.google.com/search/docs/advanced/guidelines/duplicate-content 

There is a discussion in which the author goes in detail on what he did to improve the Google ratings:
- https://github.com/gatsbyjs/gatsby/discussions/27889

**Canonical URLs**
The author in the discussion recommends to set a canonical URL. I tried it with the [gatsby-plugin-canonical-urls
](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls). This plugin added a canonical URL to every page, but not with consistent trailing slashes (for blog posts they were missing). After that I tried [gatsby-plugin-react-helmet-canonical-urls](https://github.com/NickCis/gatsby-plugin-react-helmet-canonical-urls), but it had the same issue. The plugins don't provide a simple function to overwrite the canonical URL so I didn't want to invest anymore time on it. If we want to have it, we need to build it on our own.
I'm not sure if this is really necessary, as all redirect are working properly and should therefore make the canonical URL obsolete.  

**Backlinks**
Users will probably link to our pages without the trailing slash, as this gets removed in the address bar by default. I have no idea if this has a negative impact because we are using only trailing slashes in the `sitemap.xml` and for internal links. Like with the canonical URLs I would think that this shouldn't be a problem as we have proper redirect, but maybe we can ask some SEO expert.