### PR TITLE
feat: add subtitle and correct title style to blog overview page

### DIFF
--- a/blog-posts/optimze-gatsby-urls.md
+++ b/blog-posts/optimze-gatsby-urls.md
@@ -166,7 +166,7 @@ If there is a path without a trailing slash, you will now get a warning in the c
 trailing slash here, as the problem should be solved at the root - paths without a trailing slash will lead to potential
 follow-up problems.
 
-**Canonical**
+### Canonical
 
 A canonical URL is like an ID for a page. If your page has multiple URLs for the same page, the search engine uses the
 canonical URL to match them together. If the document wouldn't have a canonical URL, the search engine marks the content

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -5,9 +5,8 @@ import { FluidObject } from 'gatsby-image';
 
 import SEO from '../components/seo';
 import Layout from '../components/layout/layout';
-import { up } from '../components/breakpoint/breakpoint';
 import { Grid, GridItem } from '../components/grid/grid';
-import { PageTitle } from '../components/typography/typography';
+import { PageTitle, Text } from '../components/typography/typography';
 import { BlogCard } from '../components/cards/blog-card';
 import { formatDate } from '../components/util/format-date';
 import { getImage, IGatsbyImageData } from 'gatsby-plugin-image';
@@ -36,12 +35,11 @@ interface AllBlogPostsQuery {
 }
 
 const BlogPageTitle = styled(PageTitle)`
-  color: ${(props) => props.theme.palette.text.headerLight};
   margin-bottom: 48px;
+`;
 
-  ${up('md')} {
-    margin-bottom: 80px;
-  }
+const BlogPageSubTitl = styled(Text)`
+  margin-bottom: 40px;
 `;
 
 const BlogPage: React.FC = () => {
@@ -84,6 +82,14 @@ const BlogPage: React.FC = () => {
       <Grid center>
         <GridItem>
           <BlogPageTitle>Blog</BlogPageTitle>
+        </GridItem>
+        <GridItem md={8}>
+          <BlogPageSubTitl>
+            In our blog, our developers and designers talk about the latest
+            trends and know-how around tech and especially about our latest
+            learnings and insights on how to create incredibly good software for
+            the web.
+          </BlogPageSubTitl>
         </GridItem>
       </Grid>
       <Grid center>

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -35,10 +35,10 @@ interface AllBlogPostsQuery {
 }
 
 const BlogPageTitle = styled(PageTitle)`
-  margin-bottom: 48px;
+  margin-bottom: 40px;
 `;
 
-const BlogPageSubTitl = styled(Text)`
+const BlogPageSubTitle = styled(Text)`
   margin-bottom: 40px;
 `;
 
@@ -84,12 +84,11 @@ const BlogPage: React.FC = () => {
           <BlogPageTitle>Blog</BlogPageTitle>
         </GridItem>
         <GridItem md={8}>
-          <BlogPageSubTitl>
-            In our blog, our developers and designers talk about the latest
-            trends and know-how around tech and especially about our latest
-            learnings and insights on how to create incredibly good software for
-            the web.
-          </BlogPageSubTitl>
+          <BlogPageSubTitle>
+            Our developers and designers talk about the latest trends and
+            know-how around tech, especially about our latest learnings and
+            insights on creating good software for the web.
+          </BlogPageSubTitle>
         </GridItem>
       </Grid>
       <Grid center>


### PR DESCRIPTION
> Feel free to merge this PR after approval

I aligned the title style and added the subtitle to the blog overview page:

<img width="1177" alt="Screenshot 2021-07-16 at 13 14 47" src="https://user-images.githubusercontent.com/7814926/125939376-db4fb3e6-904b-461d-ab1c-b76e73067631.png">
