### PR TITLE
feat: add shortSummary to overview when it is available

### DIFF
--- a/blog-posts/angular-inject-the-injector.md
+++ b/blog-posts/angular-inject-the-injector.md
@@ -2,8 +2,8 @@
 path: "/blog/angular-inject-the-injector/"
 date: "2021-06-08"
 title: "The \"Inject the Injector\" pattern"
-featuredImage: images/georgios-kaleadis-aBTfTMsOCOI-unsplash.jpg 
-shortSummary: A coding pattern to prevent breaking changes when dealing with injections in base classes used in distributed libraries
+featuredImage: images/georgios-kaleadis-aBTfTMsOCOI-unsplash.jpg
+seoMetaText: A coding pattern to prevent breaking changes when dealing with injections in base classes used in distributed libraries
 attribution:
     creator: Georgios Kaleadis
     source: https://unsplash.com/photos/aBTfTMsOCOI

--- a/blog-posts/angular-workshop-2019.md
+++ b/blog-posts/angular-workshop-2019.md
@@ -3,7 +3,7 @@ path: "/blog/angular-workshop-kaiserx-allianz-2018/"
 date: "2018-12-01"
 title: Angular Advanced Workshop (2018)
 featuredImage: images/angular.png
-shortSummary: Our Open Source 3-day Angular Advanced Workshop we conducted for KaiserX (Allianz). 
+seoMetaText: Our Open Source 3-day Angular Advanced Workshop we conducted for KaiserX (Allianz). 
 author: Georgios Kaleadis
 authorSummary: CTO at Satellytes
 ---

--- a/blog-posts/howto-blog-post.md
+++ b/blog-posts/howto-blog-post.md
@@ -5,6 +5,7 @@ title: "How to do a blog post"
 featuredImage: images/space.jpg
 author: "Georgios Kaleadis & Fabian Dietenberger"
 authorSummary: "CTO and Senior Developer at Satellytes"
+teaserText: "Learn how to properly write a blog post – in terms of formatting – so that everything is rendered properly & our blog looks super shiny."
 attribution:
   creator: upklyak
   source: https://www.freepik.com/free-vector/space-landscape-night_13748451.htm
@@ -19,8 +20,11 @@ learn how to properly write a blog post – in terms of formatting – so that e
 
 <!-- stop excerpt -->
 
-## Excerpt
-See the comment `<!-- stop excerpt -->` in the markdown file above this section? That's the stop word for the excerpt. You don't need to use it as gatsby will extract an excerpt from the given markdown content with some heuristic, but that code word gives you the power to shorten it.
+## Teaser
+You can write a short text that is used as a teaser of your article on the blog overview page. To do this, set the `teaserText` tag in the metadata of your article and add a short summary.
+
+Instead of a self-written text you can also use an excerpt from your article as a teaser: See the comment `<!-- stop excerpt -->` in the markdown file above this section? That's the stop word for the excerpt. You don't need to use it as gatsby will extract an excerpt from the given markdown content with some heuristic, but that code word gives you the power to shorten it.
+
 
 ## Accessibility
 Keep in mind that blog posts do always start with a `h1` to show the blog post title.

--- a/blog-posts/monorepo-code-owner.md
+++ b/blog-posts/monorepo-code-owner.md
@@ -3,7 +3,7 @@ path: "/blog/monorepo-codeowner-github-enterprise/"
 date: "2021-07-09"
 title: Every big monorepo needs the CODEOWNERS feature
 featuredImage: images/chang-duong-Sj0iMtq_Z4w-unsplash.jpg
-shortSummary: CODEOWNERS file help to split the code responsibilities & ownership in a monorepo.
+seoMetaText: CODEOWNERS file help to split the code responsibilities & ownership in a monorepo.
 attribution:
    creator: Chang Duong
    source: https://unsplash.com/photos/Sj0iMtq_Z4w

--- a/blog-posts/typescript-ast-type-checker.md
+++ b/blog-posts/typescript-ast-type-checker.md
@@ -2,7 +2,7 @@
 path: "/blog/typescript-ast-type-checker/"
 date: "2021-06-18"
 title: "Going beyond the Abstract Syntax Tree (AST) with the TypeScript Type Checker"
-shortSummary: How to analyze a typescript file beyond the Abstract Syntax Tree (AST) with the TS type checking utility "checker.ts"
+seoMetaText: How to analyze a typescript file beyond the Abstract Syntax Tree (AST) with the TS type checking utility "checker.ts"
 author: Georgios Kaleadis
 authorSummary: "CTO at Satellytes"
 featuredImage: images/johann-siemens-EPy0gBJzzZU-unsplash.jpg

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -25,7 +25,8 @@ interface AllBlogPostsQuery {
       date: string;
       path: string;
       title: string;
-      shortSummary?: string;
+      seoMetaText?: string;
+      teaserText?: string;
       featuredImage: IGatsbyImageData;
     };
     rawMarkdownBody: string;
@@ -100,7 +101,7 @@ const BlogPostOverview = ({ blogPosts }) => (
           large={topBlogPost}
           image={getImage(post.frontmatter.featuredImage)}
           title={post.frontmatter.title}
-          text={post.frontmatter.shortSummary ?? post.excerpt}
+          text={post.frontmatter.teaserText ?? post.excerpt}
           caption={formatDate(post.frontmatter.date)}
           link={post.frontmatter.path}
         />
@@ -131,7 +132,8 @@ export const BlogPageQuery = graphql`
                     date
                     path
                     title
-                    shortSummary
+                    seoMetaText
+                    teaserText
                     featuredImage {
                         childImageSharp {
                             gatsbyImageData(

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -25,7 +25,6 @@ interface AllBlogPostsQuery {
       date: string;
       path: string;
       title: string;
-      seoMetaText?: string;
       teaserText?: string;
       featuredImage: IGatsbyImageData;
     };
@@ -111,43 +110,42 @@ const BlogPostOverview = ({ blogPosts }) => (
 );
 
 export const BlogPageQuery = graphql`
-    query ($language: String!) {
-        locales: allLocale(filter: { language: { eq: $language } }) {
-            edges {
-                node {
-                    ns
-                    data
-                    language
-                }
-            }
+  query ($language: String!) {
+    locales: allLocale(filter: { language: { eq: $language } }) {
+      edges {
+        node {
+          ns
+          data
+          language
         }
-        allMarkdownRemark(
-            sort: { fields: frontmatter___date, order: DESC }
-            filter: { fileAbsolutePath: { regex: "/(blog-posts)/" } }
-        ) {
-            nodes {
-                id
-                excerpt(pruneLength: 500)
-                frontmatter {
-                    date
-                    path
-                    title
-                    seoMetaText
-                    teaserText
-                    featuredImage {
-                        childImageSharp {
-                            gatsbyImageData(
-                                width: 600
-                                aspectRatio: 1.77
-                                layout: CONSTRAINED
-                                placeholder: BLURRED
-                                formats: [AUTO, WEBP, AVIF]
-                            )
-                        }
-                    }
-                }
-                rawMarkdownBody
-            }
-        }
+      }
     }
+    allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
+      filter: { fileAbsolutePath: { regex: "/(blog-posts)/" } }
+    ) {
+      nodes {
+        id
+        excerpt(pruneLength: 500)
+        frontmatter {
+          date
+          path
+          title
+          teaserText
+          featuredImage {
+            childImageSharp {
+              gatsbyImageData(
+                width: 600
+                aspectRatio: 1.77
+                layout: CONSTRAINED
+                placeholder: BLURRED
+                formats: [AUTO, WEBP, AVIF]
+              )
+            }
+          }
+        }
+        rawMarkdownBody
+      }
+    }
+  }
 `;

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -25,6 +25,7 @@ interface AllBlogPostsQuery {
       date: string;
       path: string;
       title: string;
+      shortSummary?: string;
       featuredImage: IGatsbyImageData;
     };
     rawMarkdownBody: string;
@@ -99,7 +100,7 @@ const BlogPostOverview = ({ blogPosts }) => (
           large={topBlogPost}
           image={getImage(post.frontmatter.featuredImage)}
           title={post.frontmatter.title}
-          text={post.excerpt}
+          text={post.frontmatter.shortSummary ?? post.excerpt}
           caption={formatDate(post.frontmatter.date)}
           link={post.frontmatter.path}
         />
@@ -109,41 +110,42 @@ const BlogPostOverview = ({ blogPosts }) => (
 );
 
 export const BlogPageQuery = graphql`
-  query ($language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
-      edges {
-        node {
-          ns
-          data
-          language
-        }
-      }
-    }
-    allMarkdownRemark(
-      sort: { fields: frontmatter___date, order: DESC }
-      filter: { fileAbsolutePath: { regex: "/(blog-posts)/" } }
-    ) {
-      nodes {
-        id
-        excerpt(pruneLength: 500)
-        frontmatter {
-          date
-          path
-          title
-          featuredImage {
-            childImageSharp {
-              gatsbyImageData(
-                width: 600
-                aspectRatio: 1.77
-                layout: CONSTRAINED
-                placeholder: BLURRED
-                formats: [AUTO, WEBP, AVIF]
-              )
+    query ($language: String!) {
+        locales: allLocale(filter: { language: { eq: $language } }) {
+            edges {
+                node {
+                    ns
+                    data
+                    language
+                }
             }
-          }
         }
-        rawMarkdownBody
-      }
+        allMarkdownRemark(
+            sort: { fields: frontmatter___date, order: DESC }
+            filter: { fileAbsolutePath: { regex: "/(blog-posts)/" } }
+        ) {
+            nodes {
+                id
+                excerpt(pruneLength: 500)
+                frontmatter {
+                    date
+                    path
+                    title
+                    shortSummary
+                    featuredImage {
+                        childImageSharp {
+                            gatsbyImageData(
+                                width: 600
+                                aspectRatio: 1.77
+                                layout: CONSTRAINED
+                                placeholder: BLURRED
+                                formats: [AUTO, WEBP, AVIF]
+                            )
+                        }
+                    }
+                }
+                rawMarkdownBody
+            }
+        }
     }
-  }
 `;

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -37,7 +37,7 @@ interface BlogArticleTemplateProps {
         image?: string;
         author?: string;
         authorSummary?: string;
-        shortSummary?: string;
+        seoMetaText?: string;
         featuredImage: IGatsbyImageData;
         featuredImageSquared: IGatsbyImageData;
       };
@@ -78,9 +78,9 @@ const BlogHeader = ({ readingTime, frontmatter }) => {
 };
 
 const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
-  data,
-  location,
-}) => {
+                                                                   data,
+                                                                   location,
+                                                                 }) => {
   const markdown = data.markdownRemark;
 
   const { featuredImage, featuredImageSquared, attribution } =
@@ -104,7 +104,7 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
       {/*
        * SEO Notes:
        * Recommended meta description length these days is 120 - 158 characters. The lower number is relevant for mobile devices.
-       * This means authored blog posts should always come with an explicit 120 character summary (`shortSummary`). In case an author doesn't provide such a summary
+       * This means authored blog posts should always come with an explicit 120 character summary (`seoMetaText`). In case an author doesn't provide such a summary
        * we will fallback to a generated excerpt fixed to the 158 characters to provide a little bit more text as the automatic extraction is usually
        * less condense in terms of content.
        */}
@@ -112,7 +112,7 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
         title={`${markdown.frontmatter.title} | Satellytes`}
         imageUrl={markdown.fields?.socialCard}
         siteType="article"
-        description={markdown.frontmatter.shortSummary ?? markdown.excerpt}
+        description={markdown.frontmatter.seoMetaText ?? markdown.excerpt}
         location={location}
         noTranslation={true}
       />
@@ -132,63 +132,63 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
 };
 
 export const BlogPostPageQuery = graphql`
-  query ($path: String!, $language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
-      edges {
-        node {
-          ns
-          data
-          language
+    query ($path: String!, $language: String!) {
+        locales: allLocale(filter: { language: { eq: $language } }) {
+            edges {
+                node {
+                    ns
+                    data
+                    language
+                }
+            }
         }
-      }
-    }
-    markdownRemark(frontmatter: { path: { eq: $path } }) {
-      html
-      htmlAst
-      fields {
-        socialCard
-        readingTime {
-          minutes
-        }
-      }
-      excerpt(pruneLength: 158)
-      frontmatter {
-        attribution {
-          creator
-          source
-        }
-        date
-        path
-        title
-        author
-        authorSummary
-        shortSummary
+        markdownRemark(frontmatter: { path: { eq: $path } }) {
+            html
+            htmlAst
+            fields {
+                socialCard
+                readingTime {
+                    minutes
+                }
+            }
+            excerpt(pruneLength: 158)
+            frontmatter {
+                attribution {
+                    creator
+                    source
+                }
+                date
+                path
+                title
+                author
+                authorSummary
+                seoMetaText
 
-        featuredImage {
-          childImageSharp {
-            gatsbyImageData(
-              aspectRatio: 2.5
-              layout: FULL_WIDTH
-              placeholder: BLURRED
-              formats: [AUTO, WEBP, AVIF]
-            )
-          }
-        }
+                featuredImage {
+                    childImageSharp {
+                        gatsbyImageData(
+                            aspectRatio: 2.5
+                            layout: FULL_WIDTH
+                            placeholder: BLURRED
+                            formats: [AUTO, WEBP, AVIF]
+                        )
+                    }
+                }
 
-        featuredImageSquared: featuredImage {
-          childImageSharp {
-            gatsbyImageData(
-              aspectRatio: 1
-              layout: FULL_WIDTH
-              placeholder: BLURRED
-              formats: [AUTO, WEBP, AVIF]
-            )
-          }
+                featuredImageSquared: featuredImage {
+                    childImageSharp {
+                        gatsbyImageData(
+                            aspectRatio: 1
+                            layout: FULL_WIDTH
+                            placeholder: BLURRED
+                            formats: [AUTO, WEBP, AVIF]
+                        )
+                    }
+                }
+            }
+            rawMarkdownBody
         }
-      }
-      rawMarkdownBody
     }
-  }
 `;
 
 export default BlogArticleTemplate;

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -78,9 +78,9 @@ const BlogHeader = ({ readingTime, frontmatter }) => {
 };
 
 const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
-                                                                   data,
-                                                                   location,
-                                                                 }) => {
+  data,
+  location,
+}) => {
   const markdown = data.markdownRemark;
 
   const { featuredImage, featuredImageSquared, attribution } =
@@ -132,63 +132,63 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
 };
 
 export const BlogPostPageQuery = graphql`
-    query ($path: String!, $language: String!) {
-        locales: allLocale(filter: { language: { eq: $language } }) {
-            edges {
-                node {
-                    ns
-                    data
-                    language
-                }
-            }
+  query ($path: String!, $language: String!) {
+    locales: allLocale(filter: { language: { eq: $language } }) {
+      edges {
+        node {
+          ns
+          data
+          language
         }
-        markdownRemark(frontmatter: { path: { eq: $path } }) {
-            html
-            htmlAst
-            fields {
-                socialCard
-                readingTime {
-                    minutes
-                }
-            }
-            excerpt(pruneLength: 158)
-            frontmatter {
-                attribution {
-                    creator
-                    source
-                }
-                date
-                path
-                title
-                author
-                authorSummary
-                seoMetaText
-
-                featuredImage {
-                    childImageSharp {
-                        gatsbyImageData(
-                            aspectRatio: 2.5
-                            layout: FULL_WIDTH
-                            placeholder: BLURRED
-                            formats: [AUTO, WEBP, AVIF]
-                        )
-                    }
-                }
-
-                featuredImageSquared: featuredImage {
-                    childImageSharp {
-                        gatsbyImageData(
-                            aspectRatio: 1
-                            layout: FULL_WIDTH
-                            placeholder: BLURRED
-                            formats: [AUTO, WEBP, AVIF]
-                        )
-                    }
-                }
-            }
-            rawMarkdownBody
-        }
+      }
     }
+    markdownRemark(frontmatter: { path: { eq: $path } }) {
+      html
+      htmlAst
+      fields {
+        socialCard
+        readingTime {
+          minutes
+        }
+      }
+      excerpt(pruneLength: 158)
+      frontmatter {
+        attribution {
+          creator
+          source
+        }
+        date
+        path
+        title
+        author
+        authorSummary
+        seoMetaText
+
+        featuredImage {
+          childImageSharp {
+            gatsbyImageData(
+              aspectRatio: 2.5
+              layout: FULL_WIDTH
+              placeholder: BLURRED
+              formats: [AUTO, WEBP, AVIF]
+            )
+          }
+        }
+
+        featuredImageSquared: featuredImage {
+          childImageSharp {
+            gatsbyImageData(
+              aspectRatio: 1
+              layout: FULL_WIDTH
+              placeholder: BLURRED
+              formats: [AUTO, WEBP, AVIF]
+            )
+          }
+        }
+      }
+      rawMarkdownBody
+    }
+  }
 `;
 
 export default BlogArticleTemplate;


### PR DESCRIPTION
The short summary of the blogpost on the overview page is now taken from the "shortSummary" tag of the blogpost markdown. This gives the author the possibility to describe his article precisely.