### PR TITLE
fix: skip alternate url for untranslated pages

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -16,6 +16,7 @@ interface SeoProps {
   siteType?: string;
   noIndex?: boolean;
   noTranslation?: boolean;
+  translatedPath?: string;
   location: Location;
 }
 
@@ -25,6 +26,7 @@ const SEO: React.FC<SeoProps> = ({
   imageUrl,
   siteType,
   noIndex,
+  translatedPath,
   noTranslation,
   location,
 }) => {
@@ -58,7 +60,11 @@ const SEO: React.FC<SeoProps> = ({
   const listLocalizedVersions = (pathName) => {
     return LANGUAGES.map((lang) => {
       const languagePath = lang === 'en' ? '' : `/${lang}`;
-      const href = `${location.origin}${languagePath}${pathName}`;
+      const pathNameWithSlashes =
+        language !== lang && translatedPath
+          ? prependAndAppendTrailingSlash(translatedPath)
+          : pathName;
+      const href = `${location.origin}${languagePath}${pathNameWithSlashes}`;
       return <link rel="alternate" href={href} hrefLang={lang} key={lang} />;
     });
   };
@@ -128,6 +134,11 @@ const SEO: React.FC<SeoProps> = ({
       {!noTranslation && listLocalizedVersions(currentPathname)}
     </Helmet>
   );
+};
+
+const prependAndAppendTrailingSlash = (path) => {
+  const prependedPath = path.startsWith('/') ? path : `/${path}`;
+  return prependedPath.endsWith('/') ? prependedPath : `${prependedPath}/`;
 };
 
 export default SEO;

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -15,7 +15,7 @@ interface SeoProps {
   imageUrl?: string;
   siteType?: string;
   noIndex?: boolean;
-  translation?: string;
+  noTranslation?: boolean;
   location: Location;
 }
 
@@ -25,7 +25,7 @@ const SEO: React.FC<SeoProps> = ({
   imageUrl,
   siteType,
   noIndex,
-  translation,
+  noTranslation,
   location,
 }) => {
   const { site } = useStaticQuery(
@@ -52,29 +52,14 @@ const SEO: React.FC<SeoProps> = ({
 
   const currentPathname = location.pathname.replace('/de', '');
 
-  const prependAndAppendTrailingSlash = (path) => {
-    const prependedPath = path.startsWith('/') ? path : `/${path}`;
-    return prependedPath.endsWith('/') ? prependedPath : `${prependedPath}/`;
-  };
-
   // functions returns links for each localized version of the page (en and de).
   // This will help Google to show the most appropriate version by language,
   // for more information: https://developers.google.com/search/docs/advanced/crawling/localized-versions#html
-  const listLocalizedVersions = () => {
+  const listLocalizedVersions = (pathName) => {
     return LANGUAGES.map((lang) => {
-      const href = `${location.origin}${lang === 'en' ? '' : `/${lang}`}`;
-      const pathname =
-        language !== lang && translation
-          ? prependAndAppendTrailingSlash(translation)
-          : currentPathname;
-      return (
-        <link
-          rel="alternate"
-          href={href.concat(pathname)}
-          hrefLang={lang}
-          key={lang}
-        />
-      );
+      const languagePath = lang === 'en' ? '' : `/${lang}`;
+      const href = `${location.origin}${languagePath}${pathName}`;
+      return <link rel="alternate" href={href} hrefLang={lang} key={lang} />;
     });
   };
 
@@ -140,7 +125,7 @@ const SEO: React.FC<SeoProps> = ({
       />
 
       {/* -- Alternate Links --*/}
-      {listLocalizedVersions()}
+      {!noTranslation && listLocalizedVersions(currentPathname)}
     </Helmet>
   );
 };

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -114,6 +114,7 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
         siteType="article"
         description={markdown.frontmatter.shortSummary ?? markdown.excerpt}
         location={location}
+        noTranslation={true}
       />
       <Grid center>
         <GridItem xs={0} md={2} />

--- a/src/templates/career-details.tsx
+++ b/src/templates/career-details.tsx
@@ -116,7 +116,8 @@ const CareerPage: React.FC<CareerPageProps> = (props): JSX.Element => {
           description={t('career.seo.description-detail', {
             name: pageContext.position.name,
           })}
-          translation={pageContext.translation}
+          translatedPath={pageContext.translation}
+          noTranslation={!pageContext.translation}
           location={props.location}
         />
         <Grid>


### PR DESCRIPTION
This PR will skip the alternate link header for blog posts, as they don't have a translated version.

Example URL with alternate header: https://satellytescommain-fixalternateurl.gtsb.io/
Blog Post URL without alternate header: https://satellytescommain-fixalternateurl.gtsb.io/blog/github-billing-dashboard/