### PR TITLE
feat: added image and code block caption with example

### DIFF
--- a/blog-posts/github-billing-dashboard.md
+++ b/blog-posts/github-billing-dashboard.md
@@ -25,13 +25,10 @@ This can be a problem if you have multiple projects, as it’s not obvious which
 The following screenshot shows all the billing information you get from the GitHub Settings. No historical data, no expense per service.
 
 ![screenshot of the billing settings in a Github account](images/gh-billing-dashboard-screenshot-of-gh-billing-settings.png)
-*Screenshot of the billing settings in a Github account*
-
 
 And this is what you get from the GitHub Billing Dashboard. Costs per service per month with historic data:
 
 ![screenshot of the Github billing dashboard with some charts](images/gh-billing-dashboard-screenshot-of-gh-dashboard.png)
-*Screenshot of the Github billing dashboard with some charts*
 
 This blog post gives you some insights into how we build it.
 
@@ -61,8 +58,6 @@ Date,Product,Repository Slug,Quantity,Unit Type,Price Per Unit,Actions Workflow,
 2021-06-15,actions,sample-repository3,26,UBUNTU,$0.008,.github/workflows/main.yml,
 2021-06-15,actions,sample-repository2,17,UBUNTU,$0.008,.github/workflows/integration-test.yml,
 ```
-
-<figure>
 
 ```tsx
 export interface UsageReportCsvEntry {
@@ -98,8 +93,6 @@ parse<UsageReportCsvEntry>(file, {
 	},
 });
 ```
-<figcaption>Code Example: Conversion from CVS to JSON</figcaption>
-</figure>
 
 ### Recharts
 

--- a/blog-posts/github-billing-dashboard.md
+++ b/blog-posts/github-billing-dashboard.md
@@ -25,9 +25,14 @@ This can be a problem if you have multiple projects, as it’s not obvious which
 The following screenshot shows all the billing information you get from the GitHub Settings. No historical data, no expense per service.
 
 ![screenshot of the billing settings in a Github account](images/gh-billing-dashboard-screenshot-of-gh-billing-settings.png)
+*Screenshot of the billing settings in a Github account*
+
 
 And this is what you get from the GitHub Billing Dashboard. Costs per service per month with historic data:
+
 ![screenshot of the Github billing dashboard with some charts](images/gh-billing-dashboard-screenshot-of-gh-dashboard.png)
+*Screenshot of the Github billing dashboard with some charts*
+
 This blog post gives you some insights into how we build it.
 
 ## Technologies and Libraries
@@ -56,6 +61,8 @@ Date,Product,Repository Slug,Quantity,Unit Type,Price Per Unit,Actions Workflow,
 2021-06-15,actions,sample-repository3,26,UBUNTU,$0.008,.github/workflows/main.yml,
 2021-06-15,actions,sample-repository2,17,UBUNTU,$0.008,.github/workflows/integration-test.yml,
 ```
+
+<figure>
 
 ```tsx
 export interface UsageReportCsvEntry {
@@ -91,6 +98,8 @@ parse<UsageReportCsvEntry>(file, {
 	},
 });
 ```
+<figcaption>Code Example: Conversion from CVS to JSON</figcaption>
+</figure>
 
 ### Recharts
 

--- a/blog-posts/howto-blog-post.md
+++ b/blog-posts/howto-blog-post.md
@@ -53,7 +53,25 @@ Here a 4MB picture that should get prepared by gatsby properly.
 We don't want to load 4MB but the processed image:
 
 ![twilight coloured imaginary planet where the surface shows some pink crystals growing and three planets visible in the sky](./images/space.jpg)
-<a href='https://www.freepik.com/vectors/star'>Star vector created by upklyak</a>
+*[Star vector created by upklyak](https://www.freepik.com/vectors/star)*
+
+#### Image caption
+
+To maintain a valid HTML image structure and an easily readable markdown-file, the caption for the image can be added like this:
+```
+![alt-text](./image-url)
+*Picture 1: This is an example caption.*
+```
+
+which is resolved to:
+
+```html
+<p>
+  <img src='./image-url' alt='alt-text'/>
+  <em>Picture 1: This is an example caption.</em>
+</p>
+```
+<br/>
 
 This is a PDF file that should get processed and copied to `public/`:
 [My PDF Download](./images/test.pdf)
@@ -67,7 +85,7 @@ determine the expected syntax. If you omit
 
 ```
 ~~~javascript
-cosnt myJavaScrip = true;
+const myJavaScrip = true;
 ~~~
 ```
 
@@ -166,6 +184,16 @@ footer p {
 
 ```
 
+#### Code Block Caption
+
+A code block caption can be added with:
+```html
+<figure>
+  
+  // Code Block
+  <figcaption>Code Block 1: This is an example for a caption.</figcaption>
+</figure>
+```
 
 ### Tables (tbd)
 Super cheap design that we might want to update.

--- a/src/components/markdown/custom-components.tsx
+++ b/src/components/markdown/custom-components.tsx
@@ -1,4 +1,7 @@
 import {
+  CodeBlockCaption,
+  Figure,
+  ImageCaption,
   SmallTitle,
   SubTitle,
   Text,
@@ -154,6 +157,15 @@ const customSatellytesComponents = {
   },
   p(props) {
     return <Text>{props.children}</Text>;
+  },
+  figure(props) {
+    return <Figure>{props.children}</Figure>;
+  },
+  figcaption(props) {
+    return <CodeBlockCaption>{props.children}</CodeBlockCaption>;
+  },
+  em(props) {
+    return <ImageCaption>{props.children}</ImageCaption>;
   },
   table(props) {
     return (

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -130,6 +130,26 @@ export const CaptionText = styled.p`
   color: #668cff;
 `;
 
+export const ImageCaption = styled.em`
+  margin: 0px;
+  font-size: 16px;
+  font-style: normal;
+  line-height: 28px;
+
+  opacity: 0.5;
+`;
+
+export const CodeBlockCaption = styled.figcaption`
+  margin-bottom: 32px;
+  font-size: 16px;
+
+  opacity: 0.5;
+`;
+
+export const Figure = styled.figure`
+  margin: 10px 0px;
+`;
+
 /**
  *
  * Image Card


### PR DESCRIPTION
pr contains:
- components for image and code block caption with changeable design
- example for both in a blog article

to test: [https://satellytescommain-featimagecaptioninmarkdown.gtsb.io/blog/github-billing-dashboard/](https://satellytescommain-featimagecaptioninmarkdown.gtsb.io/blog/github-billing-dashboard/)

technical notes:
- the caption of images is styled with css: [https://thesynack.com/posts/markdown-captions/#targeting-captions-with-css](https://thesynack.com/posts/markdown-captions/#targeting-captions-with-css)
- the code block caption is done with `<figurecaption>` [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)
- image captions can be done with `<figurecaption>` as well, but I would say the first option is easier to write (as it does not require additional html)
