### PR TITLE
feat: add teaserText and seoMetaText to the GH dashboard blogpost

### DIFF
--- a/blog-posts/github-billing-dashboard.md
+++ b/blog-posts/github-billing-dashboard.md
@@ -5,6 +5,8 @@ title: "GitHub CSV Billing Dashboard"
 featuredImage: images/gh-billing-dashboard-cockpit.jpg
 author: "Felix Hofmann and Fabian Dietenberger"
 authorSummary: "Working Student and Senior Developer at Satellytes"
+teaserText: We have developed a dashboard that graphically displays the costs incurred by GitHub Actions. In this article you can learn more about the technologies and libraries we used in this project. It also explains some background information about GitHub Actions and the corresponding costs.
+seoMetaText: Some background information about our self-developed GitHub Billing Dashboard
 attribution:
     creator: Launde Morel
     source: https://unsplash.com/photos/4VSsq9ErzOs


### PR DESCRIPTION
I have added a teaser and the seoMetaText to my blog post about the GitHub Billing Dashboard.

URL: https://satellytescommain-feataddteasertoghdashboardpost.gtsb.io/blog/