### PR TITLE
fix: use semantically correct html for the language switch

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -152,7 +152,7 @@ module.exports = {
               }
             `,
             output: RSS_FEED_URL,
-            title: 'Satellytes Blog Feed',
+            title: 'Satellytes',
             // optional configuration to insert feed reference in pages:
             // if `string` is used, it will be used to create RegExp and then test if pathname of
             // current page satisfied this regular expression;

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -3,11 +3,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from '../links/links';
 
-const UnstyledListItem = styled.li`
-  list-style-type: none;
-  display: inline;
-`;
-
 const StyledLanguageLink = styled(Link)<{ selected?: boolean }>`
   margin: 1px 0 1px 12px;
   font-weight: bold;
@@ -28,25 +23,22 @@ export const LanguageSwitch = ({
 
   return (
     <nav aria-label={languageSwitchLabel} className={className}>
-      <ul>
-        {languages.map((languageOfLink) => {
-          return (
-            <UnstyledListItem key={languageOfLink}>
-              <StyledLanguageLink
-                to={
-                  language !== languageOfLink && translation
-                    ? translation
-                    : originalPath
-                }
-                language={languageOfLink}
-                selected={language === languageOfLink}
-              >
-                {languageOfLink}
-              </StyledLanguageLink>
-            </UnstyledListItem>
-          );
-        })}
-      </ul>
+      {languages.map((languageOfLink) => {
+        return (
+          <StyledLanguageLink
+            key={languageOfLink}
+            to={
+              language !== languageOfLink && translation
+                ? translation
+                : originalPath
+            }
+            language={languageOfLink}
+            selected={language === languageOfLink}
+          >
+            {languageOfLink}
+          </StyledLanguageLink>
+        );
+      })}
     </nav>
   );
 };

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -3,8 +3,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from '../links/links';
 
+const UnstyledListItem = styled.li`
+  list-style-type: none;
+  display: inline;
+`;
+
 const StyledLanguageLink = styled(Link)<{ selected?: boolean }>`
-  margin: 1px 0px 1px 12px;
+  margin: 1px 0 1px 12px;
   font-weight: bold;
   font-size: 14px;
   line-height: 110%;
@@ -18,26 +23,30 @@ export const LanguageSwitch = ({
   translation,
   className = 'language-switch',
 }) => {
-  const { languages, language, originalPath } = useI18next();
+  const { languages, language, originalPath, t } = useI18next();
+  const languageSwitchLabel = t('navigation.language-aria');
 
   return (
-    <div className={className}>
-      {languages.map((languageOfLink) => {
-        return (
-          <StyledLanguageLink
-            key={languageOfLink}
-            to={
-              language !== languageOfLink && translation
-                ? translation
-                : originalPath
-            }
-            language={languageOfLink}
-            selected={language === languageOfLink}
-          >
-            {languageOfLink}
-          </StyledLanguageLink>
-        );
-      })}
-    </div>
+    <nav aria-label={languageSwitchLabel} className={className}>
+      <ul>
+        {languages.map((languageOfLink) => {
+          return (
+            <UnstyledListItem key={languageOfLink}>
+              <StyledLanguageLink
+                to={
+                  language !== languageOfLink && translation
+                    ? translation
+                    : originalPath
+                }
+                language={languageOfLink}
+                selected={language === languageOfLink}
+              >
+                {languageOfLink}
+              </StyledLanguageLink>
+            </UnstyledListItem>
+          );
+        })}
+      </ul>
+    </nav>
   );
 };

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -112,6 +112,8 @@
     "info": "Information über die Erhebung personenbezogener Daten"
   },
   "navigation": {
+    "language-aria": "Sprachauswahl",
+    "main-navigation-aria": "Hauptnavigation",
     "menu": "Menu",
     "imprint": "Impressum",
     "data-privacy": "Datenschutz",

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -112,6 +112,8 @@
     "info": "Information on the collection of personal data"
   },
   "navigation": {
+    "language-aria": "Language Select",
+    "main-navigation-aria": "Main Navigation",
     "menu": "Navigation",
     "imprint": "Imprint",
     "data-privacy": "Data Privacy",


### PR DESCRIPTION
I tried to fix our broken Google result ("Ende" page because of `en`/`de` language switch) with a more expressive HTML syntax. I'm not 100% sure if it works, but optimistic:
- added a `nav` around the whole switch
- put the links into a unordered list

**Screenshot of the bug** 
<img width="716" alt="Screenshot 2021-09-27 at 08 45 50" src="https://user-images.githubusercontent.com/7814926/134857748-c53ed762-d03f-4251-97e0-8d661bcd752e.png">

- also, having `Satellytes` as RSS feed title is enough

<img width="312" alt="Screenshot 2021-09-27 at 08 47 44" src="https://user-images.githubusercontent.com/7814926/134858056-f2a089e3-8b60-4735-ae47-1e70301b7fa2.png">
