### PR TITLE
feat: add new header

### DIFF
--- a/src/@types/styled-components.d.ts
+++ b/src/@types/styled-components.d.ts
@@ -38,6 +38,7 @@ declare module 'styled-components' {
         body: string;
         card: string;
         footer: string;
+        headerTransperent: string;
         leadbox: string;
       };
     };

--- a/src/@types/styled-components.d.ts
+++ b/src/@types/styled-components.d.ts
@@ -22,6 +22,7 @@ declare module 'styled-components' {
         secondary: string;
         header: string;
         headerLight: string;
+        headerHover: string;
         breadcrumb: string;
         link: {
           default: string;

--- a/src/@types/styled-components.d.ts
+++ b/src/@types/styled-components.d.ts
@@ -39,7 +39,7 @@ declare module 'styled-components' {
         body: string;
         card: string;
         footer: string;
-        headerTransperent: string;
+        headerTransparent: string;
         leadbox: string;
       };
     };

--- a/src/components/header/header.stories.tsx
+++ b/src/components/header/header.stories.tsx
@@ -15,10 +15,19 @@ const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
 export const Regular = Template.bind({});
 Regular.args = {
   siteTitle: 'Satellytes',
+  $lightTheme: false,
+  showLanguageSwitch: true,
 };
 
-export const WithLanguageSwitch = Template.bind({});
-WithLanguageSwitch.args = {
+export const WithLightTheme = Template.bind({});
+WithLightTheme.args = {
   ...Regular.args,
-  showLanguageSwitch: true,
+  $lightTheme: true,
+};
+
+export const WithLightThemeTransparent = Template.bind({});
+WithLightThemeTransparent.args = {
+  ...Regular.args,
+  $lightTheme: true,
+  transparent: true,
 };

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -155,7 +155,10 @@ const Header: React.FC<HeaderProps> = (props) => {
       </SiteTitle>
       <Wrapper>
         {(props.translation || props.showLanguageSwitch) && (
-          <LanguageSwitch translation={props.translation} />
+          <LanguageSwitch
+            translation={props.translation}
+            $lightTheme={Boolean(!isHeaderTransparent && props.$lightTheme)}
+          />
         )}
         <SiteMenu
           aria-label="Open menu"

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -27,7 +27,10 @@ const StyledHeader = styled.header<{
       : props.$lightTheme
       ? props.theme.palette.background.bodyLight
       : props.theme.palette.background.body};
-
+  background: ${(props) =>
+    props.$transparent &&
+    props.$lightTheme &&
+    props.theme.palette.background.headerTransperent};
   height: ${HEADER_HEIGHT};
   display: flex;
   justify-content: space-between;
@@ -35,7 +38,9 @@ const StyledHeader = styled.header<{
   padding: 0 24px;
 
   border-bottom: ${(props) =>
-    props.$lightTheme ? '1px solid rgba(32, 40, 64, 0.05)' : 'none'};
+    props.$lightTheme && !props.$transparent
+      ? '1px solid rgba(32, 40, 64, 0.05)'
+      : 'none'};
 `;
 
 const HeaderSwoosh = styled(Swoosh)`

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -59,10 +59,17 @@ const SiteTitle = styled(Link)<{ $lightTheme: boolean }>`
   font-size: 20px;
   font-weight: bold;
   text-decoration: none;
+  transition: color 0.2s;
+
   color: ${(props) =>
     props.$lightTheme
       ? props.theme.palette.text.headerLight
       : props.theme.palette.text.header};
+
+  &:hover {
+    color: ${(props) =>
+      !props.$lightTheme && props.theme.palette.text.headerHover};
+  }
 `;
 
 const SiteMenu = styled.button<{ $lightTheme: boolean }>`
@@ -96,6 +103,13 @@ const SiteMenu = styled.button<{ $lightTheme: boolean }>`
       props.$lightTheme
         ? props.theme.palette.text.headerLight
         : props.theme.palette.text.header};
+  }
+
+  &:hover {
+    .bar {
+      background-color: ${(props) =>
+        !props.$lightTheme && props.theme.palette.text.headerHover};
+    }
   }
 `;
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -83,7 +83,7 @@ const SiteMenu = styled.button<{ $lightTheme: boolean }>`
   .bar {
     background-color: ${(props) =>
       props.$lightTheme
-        ? props.theme.palette.text.headerLight
+        ? props.theme.palette.text.default
         : props.theme.palette.text.header};
   }
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -24,7 +24,7 @@ const StyledHeader = styled.header<{
   background: ${(props) =>
     props.$transparent
       ? props.$lightTheme
-        ? props.theme.palette.background.headerTransperent
+        ? props.theme.palette.background.headerTransparent
         : 'none'
       : props.$lightTheme
       ? props.theme.palette.background.bodyLight

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -19,7 +19,7 @@ const StyledHeader = styled.header<{
   top: 0;
   width: 100%;
   z-index: 100;
-  transition: background-color 0.2s;
+  transition: background 0.2s;
 
   background-color: ${(props) =>
     props.$transparent
@@ -32,16 +32,10 @@ const StyledHeader = styled.header<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 16px;
+  padding: 0 24px;
 
   border-bottom: ${(props) =>
-    props.$lightTheme
-      ? '1px solid rgba(32, 40, 64, 0.05)'
-      : '1px solid rgba(255, 255, 255, 0.1)'};
-
-  ${up('md')} {
-    padding: 0 24px;
-  }
+    props.$lightTheme ? '1px solid rgba(32, 40, 64, 0.05)' : 'none'};
 `;
 
 const HeaderSwoosh = styled(Swoosh)`

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -21,16 +21,15 @@ const StyledHeader = styled.header<{
   z-index: 100;
   transition: background 0.2s;
 
-  background-color: ${(props) =>
+  background: ${(props) =>
     props.$transparent
-      ? 'none'
+      ? props.$lightTheme
+        ? props.theme.palette.background.headerTransperent
+        : 'none'
       : props.$lightTheme
       ? props.theme.palette.background.bodyLight
       : props.theme.palette.background.body};
-  background: ${(props) =>
-    props.$transparent &&
-    props.$lightTheme &&
-    props.theme.palette.background.headerTransperent};
+
   height: ${HEADER_HEIGHT};
   display: flex;
   justify-content: space-between;

--- a/src/components/icons/chevron.tsx
+++ b/src/components/icons/chevron.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
-export const Chevron = () => (
+export const Chevron: React.FC = (props: React.SVGAttributes<SVGElement>) => (
   <svg
+    className={props.className}
     width="6"
     height="5"
     viewBox="0 0 6 5"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <path d="M3 4.75L0 0.25H6L3 4.75Z" fill="white" />
+    <path d="M3 4.75L0 0.25H6L3 4.75Z" fill="currentColor" />
   </svg>
 );

--- a/src/components/icons/chevron.tsx
+++ b/src/components/icons/chevron.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const Chevron = () => (
+  <svg
+    width="6"
+    height="5"
+    viewBox="0 0 6 5"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M3 4.75L0 0.25H6L3 4.75Z" fill="white" />
+  </svg>
+);

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -7,22 +7,34 @@ interface LanguageSwitchProps {
   translation: any;
   className?: string;
   $lightTheme?: boolean;
+  fromNavigation?: boolean;
 }
-const StyledSelection = styled.select<{ $lightTheme: boolean }>`
+
+const StyledSelection = styled.select<{
+  $lightTheme?: boolean;
+  fromNavigation?: boolean;
+}>`
   background: none;
   border: none;
   text-transform: uppercase;
+  font-weight: bold;
+  font-size: 14px;
   color: ${(props) =>
-    props.$lightTheme
+    props.fromNavigation
+      ? props.theme.palette.background.body
+      : props.$lightTheme
       ? props.theme.palette.text.headerLight
       : props.theme.palette.text.header};
+
   appearance: none;
   margin-left: 4px;
+  cursor: pointer;
 `;
 
 export const LanguageSwitch = ({
   className = 'language-switch',
   $lightTheme,
+  fromNavigation,
 }: LanguageSwitchProps) => {
   const { languages, language, t, changeLanguage } = useI18next();
 
@@ -34,7 +46,8 @@ export const LanguageSwitch = ({
           changeLanguage(event.target.value);
         }}
         value={language}
-        $lightTheme={Boolean($lightTheme)}
+        $lightTheme={$lightTheme}
+        fromNavigation={fromNavigation}
       >
         {languages.map((languageOfLink) => (
           <option value={languageOfLink} key={languageOfLink}>

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -1,6 +1,6 @@
 import { useI18next } from 'gatsby-plugin-react-i18next';
 import React from 'react';
-import styled from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 import { Chevron } from '../icons/chevron';
 
 interface LanguageSwitchProps {
@@ -10,22 +10,46 @@ interface LanguageSwitchProps {
   fromNavigation?: boolean;
 }
 
+const getTextColor = ({
+  fromNavigation,
+  $lightTheme,
+  theme,
+}: {
+  fromNavigation?: boolean;
+  $lightTheme?: boolean;
+  theme: DefaultTheme;
+}) => {
+  if (fromNavigation || $lightTheme) {
+    return theme.palette.text.default;
+  } else {
+    return theme.palette.text.header;
+  }
+};
+
+const getTextHoverColor = ({
+  fromNavigation,
+  $lightTheme,
+  theme,
+}: {
+  fromNavigation?: boolean;
+  $lightTheme?: boolean;
+  theme: DefaultTheme;
+}) => {
+  if (fromNavigation) {
+    return theme.palette.text.header;
+  } else if (!$lightTheme) {
+    return theme.palette.text.headerHover;
+  }
+};
+
 const StyledNav = styled.nav<{
   $lightTheme?: boolean;
   fromNavigation?: boolean;
 }>`
   transition: color 0.2s;
-  color: ${(props) =>
-    props.fromNavigation || props.$lightTheme
-      ? props.theme.palette.text.default
-      : props.theme.palette.text.header};
+  color: ${(props) => getTextColor(props)};
   &:hover {
-    color: ${(props) =>
-      props.fromNavigation
-        ? props.theme.palette.text.header
-        : !props.$lightTheme &&
-          !props.fromNavigation &&
-          props.theme.palette.text.headerHover};
+    color: ${(props) => getTextHoverColor(props)};
   }
 `;
 

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -20,10 +20,8 @@ const StyledSelection = styled.select<{
   font-weight: bold;
   font-size: 14px;
   color: ${(props) =>
-    props.fromNavigation
-      ? props.theme.palette.background.body
-      : props.$lightTheme
-      ? props.theme.palette.text.headerLight
+    props.fromNavigation || props.$lightTheme
+      ? props.theme.palette.text.default
       : props.theme.palette.text.header};
 
   appearance: none;
@@ -37,10 +35,8 @@ export const StyledChevron = styled(Chevron)<{
 }>`
   margin-bottom: 2px;
   color: ${(props) =>
-    props.fromNavigation
-      ? props.theme.palette.background.body
-      : props.$lightTheme
-      ? props.theme.palette.text.headerLight
+    props.fromNavigation || props.$lightTheme
+      ? props.theme.palette.text.default
       : props.theme.palette.text.header};
 `;
 

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -53,10 +53,7 @@ const StyledNav = styled.nav<{
   }
 `;
 
-const StyledSelection = styled.select<{
-  $lightTheme?: boolean;
-  fromNavigation?: boolean;
-}>`
+const StyledSelection = styled.select`
   background: none;
   border: none;
   text-transform: uppercase;
@@ -69,10 +66,7 @@ const StyledSelection = styled.select<{
   cursor: pointer;
 `;
 
-export const StyledChevron = styled(Chevron)<{
-  $lightTheme?: boolean;
-  fromNavigation?: boolean;
-}>`
+export const StyledChevron = styled(Chevron)`
   margin-bottom: 2px;
   /*margin-right: -6px makes the Chevron clickable*/
   margin-right: -6px;
@@ -92,17 +86,12 @@ export const LanguageSwitch = ({
       $lightTheme={$lightTheme}
       fromNavigation={fromNavigation}
     >
-      <StyledChevron
-        $lightTheme={$lightTheme}
-        fromNavigation={fromNavigation}
-      />
+      <StyledChevron />
       <StyledSelection
         onChange={(event) => {
           changeLanguage(event.target.value);
         }}
         value={language}
-        $lightTheme={$lightTheme}
-        fromNavigation={fromNavigation}
       >
         {languages.map((languageOfLink) => (
           <option value={languageOfLink} key={languageOfLink}>

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -31,6 +31,19 @@ const StyledSelection = styled.select<{
   cursor: pointer;
 `;
 
+export const StyledChevron = styled(Chevron)<{
+  $lightTheme?: boolean;
+  fromNavigation?: boolean;
+}>`
+  margin-bottom: 2px;
+  color: ${(props) =>
+    props.fromNavigation
+      ? props.theme.palette.background.body
+      : props.$lightTheme
+      ? props.theme.palette.text.headerLight
+      : props.theme.palette.text.header};
+`;
+
 export const LanguageSwitch = ({
   className = 'language-switch',
   $lightTheme,
@@ -40,7 +53,10 @@ export const LanguageSwitch = ({
 
   return (
     <nav aria-label={t('navigation.language-aria')} className={className}>
-      <Chevron />
+      <StyledChevron
+        $lightTheme={$lightTheme}
+        fromNavigation={fromNavigation}
+      />
       <StyledSelection
         onChange={(event) => {
           changeLanguage(event.target.value);

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -1,44 +1,47 @@
 import { useI18next } from 'gatsby-plugin-react-i18next';
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from '../links/links';
+import { Chevron } from '../icons/chevron';
 
-const StyledLanguageLink = styled(Link)<{ selected?: boolean }>`
-  margin: 1px 0 1px 12px;
-  font-weight: bold;
-  font-size: 14px;
-  line-height: 110%;
-  cursor: pointer;
+interface LanguageSwitchProps {
+  translation: any;
+  className?: string;
+  $lightTheme?: boolean;
+}
+const StyledSelection = styled.select<{ $lightTheme: boolean }>`
+  background: none;
+  border: none;
   text-transform: uppercase;
-
-  ${({ selected }) => (selected ? `color: #668CFF;` : `color: #FFFFFF;`)}
+  color: ${(props) =>
+    props.$lightTheme
+      ? props.theme.palette.text.headerLight
+      : props.theme.palette.text.header};
+  appearance: none;
+  margin-left: 4px;
 `;
 
 export const LanguageSwitch = ({
-  translation,
   className = 'language-switch',
-}) => {
-  const { languages, language, originalPath, t } = useI18next();
+  $lightTheme,
+}: LanguageSwitchProps) => {
+  const { languages, language, t, changeLanguage } = useI18next();
 
   return (
     <nav aria-label={t('navigation.language-aria')} className={className}>
-      {languages.map((languageOfLink) => {
-        return (
-          <StyledLanguageLink
-            key={languageOfLink}
-            to={
-              language !== languageOfLink && translation
-                ? translation
-                : originalPath
-            }
-            language={languageOfLink}
-            selected={language === languageOfLink}
-            title={t(`navigation.${languageOfLink}`)}
-          >
+      <Chevron />
+      <StyledSelection
+        onChange={(event) => {
+          changeLanguage(event.target.value);
+        }}
+        value={language}
+        $lightTheme={Boolean($lightTheme)}
+      >
+        {languages.map((languageOfLink) => (
+          <option value={languageOfLink} key={languageOfLink}>
             {languageOfLink}
-          </StyledLanguageLink>
-        );
-      })}
+          </option>
+        ))}
+      </StyledSelection>
     </nav>
   );
 };

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -10,6 +10,25 @@ interface LanguageSwitchProps {
   fromNavigation?: boolean;
 }
 
+const StyledNav = styled.nav<{
+  $lightTheme?: boolean;
+  fromNavigation?: boolean;
+}>`
+  transition: color 0.2s;
+  color: ${(props) =>
+    props.fromNavigation || props.$lightTheme
+      ? props.theme.palette.text.default
+      : props.theme.palette.text.header};
+  &:hover {
+    color: ${(props) =>
+      props.fromNavigation
+        ? props.theme.palette.text.header
+        : !props.$lightTheme &&
+          !props.fromNavigation &&
+          props.theme.palette.text.headerHover};
+  }
+`;
+
 const StyledSelection = styled.select<{
   $lightTheme?: boolean;
   fromNavigation?: boolean;
@@ -19,13 +38,10 @@ const StyledSelection = styled.select<{
   text-transform: uppercase;
   font-weight: bold;
   font-size: 14px;
-  color: ${(props) =>
-    props.fromNavigation || props.$lightTheme
-      ? props.theme.palette.text.default
-      : props.theme.palette.text.header};
+  color: inherit;
 
   appearance: none;
-  margin-left: 4px;
+  padding-left: 10px;
   cursor: pointer;
 `;
 
@@ -34,10 +50,8 @@ export const StyledChevron = styled(Chevron)<{
   fromNavigation?: boolean;
 }>`
   margin-bottom: 2px;
-  color: ${(props) =>
-    props.fromNavigation || props.$lightTheme
-      ? props.theme.palette.text.default
-      : props.theme.palette.text.header};
+  /*margin-right: -6px makes the Chevron clickable*/
+  margin-right: -6px;
 `;
 
 export const LanguageSwitch = ({
@@ -48,7 +62,12 @@ export const LanguageSwitch = ({
   const { languages, language, t, changeLanguage } = useI18next();
 
   return (
-    <nav aria-label={t('navigation.language-aria')} className={className}>
+    <StyledNav
+      aria-label={t('navigation.language-aria')}
+      className={className}
+      $lightTheme={$lightTheme}
+      fromNavigation={fromNavigation}
+    >
       <StyledChevron
         $lightTheme={$lightTheme}
         fromNavigation={fromNavigation}
@@ -67,6 +86,6 @@ export const LanguageSwitch = ({
           </option>
         ))}
       </StyledSelection>
-    </nav>
+    </StyledNav>
   );
 };

--- a/src/components/layout/theme.tsx
+++ b/src/components/layout/theme.tsx
@@ -29,7 +29,7 @@ export const theme: DefaultTheme = {
       bodyLight: '#FFFFFF',
       card: '#F5F6F7',
       footer: '#4D79FF',
-      headerTransperent:
+      headerTransparent:
         'linear-gradient(180deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0) 100%);',
       leadbox: '#F7F8FA',
     },

--- a/src/components/layout/theme.tsx
+++ b/src/components/layout/theme.tsx
@@ -28,6 +28,8 @@ export const theme: DefaultTheme = {
       bodyLight: '#FFFFFF',
       card: '#F5F6F7',
       footer: '#4D79FF',
+      headerTransperent:
+        'linear-gradient(180deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0) 100%);',
       leadbox: '#F7F8FA',
     },
   },

--- a/src/components/layout/theme.tsx
+++ b/src/components/layout/theme.tsx
@@ -12,6 +12,7 @@ export const theme: DefaultTheme = {
       secondary: 'rgba(32,40,64,0.5)',
       header: '#FFFFFF',
       headerLight: '#668CFF',
+      headerHover: '#3E61EE',
       breadcrumb: 'rgba(0, 0, 0, 0.5)',
       link: {
         default: '#3E61EE',

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -268,6 +268,7 @@ const Navigation: React.FC<NavigationProps> = ({
                 <LanguageSwitchWrapper
                   translation={translation}
                   className={'language-switch'}
+                  fromNavigation
                 />
               )}
               <nav>


### PR DESCRIPTION
**Preview**
- https://satellytescommain21751-featheaderredesign.gtsb.io/

**What's included?**
- new language selection dropdown
- new icon colors
- new background & border color behavior 

**Screenshots**
[Transparent header with white icons and dark background](https://satellytescommain21751-featheaderredesign.gtsb.io/)
<img width="1425" alt="Bildschirmfoto 2021-11-09 um 08 28 12" src="https://user-images.githubusercontent.com/57712895/140880617-f22f7297-ea1b-430f-be87-a2370417c4aa.png">
[Transparent header with white icons and dark background (scrolled)](https://satellytescommain21751-featheaderredesign.gtsb.io/)
<img width="1423" alt="Bildschirmfoto 2021-11-09 um 08 29 27" src="https://user-images.githubusercontent.com/57712895/140880769-1e2ad15e-1c34-49c3-be18-6aea67b77671.png">
[Transparent header with hero ](https://satellytescommain21751-featheaderredesign.gtsb.io/blog/interview-daniel-eissing/)
<img width="1420" alt="Bildschirmfoto 2021-11-09 um 09 00 15" src="https://user-images.githubusercontent.com/57712895/140884973-23e0d2b0-9899-4092-96c7-959c57b9dd3b.png">
[Header with hero (scrolled)](https://satellytescommain21751-featheaderredesign.gtsb.io/blog/interview-daniel-eissing/)
<img width="1426" alt="Bildschirmfoto 2021-11-09 um 09 01 05" src="https://user-images.githubusercontent.com/57712895/140885060-d35298c9-00e6-4fe3-9e69-ecb75946fc53.png">
[Header with white background and separation line](https://satellytescommain21751-featheaderredesign.gtsb.io/blog/)
<img width="1425" alt="Bildschirmfoto 2021-11-09 um 09 01 50" src="https://user-images.githubusercontent.com/57712895/140885176-f4775385-e4b8-413e-84ba-c9d0bc96e8aa.png">




Corresponding ticket: https://github.com/satellytes/satellytes.com/issues/152