### PR TITLE
feat: add pagination component 

### DIFF
--- a/src/components/icons/buttons-icons/next-arrow.tsx
+++ b/src/components/icons/buttons-icons/next-arrow.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export const NextArrow: React.FC = (props: React.SVGAttributes<SVGElement>) => (
+  <svg
+    className={props.className}
+    width="40"
+    height="40"
+    viewBox="0 0 40 40"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M0 20C0 8.95431 8.95431 0 20 0C31.0457 0 40 8.95431 40 20C40 31.0457 31.0457 40 20 40C8.95431 40 0 31.0457 0 20Z"
+      fill="url(#paint0_linear_3719_16601)"
+    />
+    <path
+      d="M23 16L26 20L23 24"
+      stroke="white"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M26 20H14"
+      stroke="white"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+    />
+    <defs>
+      <linearGradient
+        id="paint0_linear_3719_16601"
+        x1="40"
+        y1="40"
+        x2="-3.39799"
+        y2="35.8913"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#543FD7" />
+        <stop offset="1" stopColor="#2756FD" />
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/src/components/icons/buttons-icons/next-arrow.tsx
+++ b/src/components/icons/buttons-icons/next-arrow.tsx
@@ -3,42 +3,18 @@ import React from 'react';
 export const NextArrow: React.FC = (props: React.SVGAttributes<SVGElement>) => (
   <svg
     className={props.className}
-    width="40"
-    height="40"
-    viewBox="0 0 40 40"
+    width="16"
+    height="12"
+    viewBox="0 0 16 12"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M0 20C0 8.95431 8.95431 0 20 0C31.0457 0 40 8.95431 40 20C40 31.0457 31.0457 40 20 40C8.95431 40 0 31.0457 0 20Z"
-      fill="url(#paint0_linear_3719_16601)"
-    />
-    <path
-      d="M23 16L26 20L23 24"
+      d="M11 2L14 6L11 10"
       stroke="white"
       strokeWidth="2.5"
       strokeLinecap="round"
     />
-    <path
-      d="M26 20H14"
-      stroke="white"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <defs>
-      <linearGradient
-        id="paint0_linear_3719_16601"
-        x1="40"
-        y1="40"
-        x2="-3.39799"
-        y2="35.8913"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#543FD7" />
-        <stop offset="1" stopColor="#2756FD" />
-      </linearGradient>
-    </defs>
+    <path d="M14 6H2" stroke="white" strokeWidth="2.5" strokeLinecap="round" />
   </svg>
 );

--- a/src/components/icons/buttons-icons/prev-arrow.tsx
+++ b/src/components/icons/buttons-icons/prev-arrow.tsx
@@ -3,42 +3,18 @@ import React from 'react';
 export const PrevArrow: React.FC = (props: React.SVGAttributes<SVGElement>) => (
   <svg
     className={props.className}
-    width="40"
-    height="40"
-    viewBox="0 0 40 40"
+    width="16"
+    height="12"
+    viewBox="0 0 16 12"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M0 20C0 8.95431 8.95431 0 20 0C31.0457 0 40 8.95431 40 20C40 31.0457 31.0457 40 20 40C8.95431 40 0 31.0457 0 20Z"
-      fill="url(#paint0_linear_3719_16600)"
-    />
-    <path
-      d="M17 16L14 20L17 24"
+      d="M5 2L2 6L5 10"
       stroke="white"
       strokeWidth="2.5"
       strokeLinecap="round"
     />
-    <path
-      d="M14 20H26"
-      stroke="white"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <defs>
-      <linearGradient
-        id="paint0_linear_3719_16600"
-        x1="40"
-        y1="40"
-        x2="-3.39799"
-        y2="35.8913"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#543FD7" />
-        <stop offset="1" stopColor="#2756FD" />
-      </linearGradient>
-    </defs>
+    <path d="M2 6H14" stroke="white" strokeWidth="2.5" strokeLinecap="round" />
   </svg>
 );

--- a/src/components/icons/buttons-icons/prev-arrow.tsx
+++ b/src/components/icons/buttons-icons/prev-arrow.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export const PrevArrow: React.FC = (props: React.SVGAttributes<SVGElement>) => (
+  <svg
+    className={props.className}
+    width="40"
+    height="40"
+    viewBox="0 0 40 40"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M0 20C0 8.95431 8.95431 0 20 0C31.0457 0 40 8.95431 40 20C40 31.0457 31.0457 40 20 40C8.95431 40 0 31.0457 0 20Z"
+      fill="url(#paint0_linear_3719_16600)"
+    />
+    <path
+      d="M17 16L14 20L17 24"
+      stroke="white"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M14 20H26"
+      stroke="white"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+    />
+    <defs>
+      <linearGradient
+        id="paint0_linear_3719_16600"
+        x1="40"
+        y1="40"
+        x2="-3.39799"
+        y2="35.8913"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#543FD7" />
+        <stop offset="1" stopColor="#2756FD" />
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/src/components/pagination/pagination.stories.tsx
+++ b/src/components/pagination/pagination.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Pagination } from './pagination';
 
@@ -25,4 +25,63 @@ Regular.args = {
   onDropdownSelect: (selectedPage) => {
     return selectedPage;
   },
+  currentPage: 1,
 };
+
+const ComponentWithPagination = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const mockData = [
+    'Blogpost: 1',
+    'Blogpost: 2',
+    'Blogpost: 3',
+    'Blogpost: 4',
+    'Blogpost: 5',
+    'Blogpost: 6',
+    'Blogpost: 7',
+    'Blogpost: 8',
+    'Blogpost: 9',
+  ];
+
+  const itemsPerPage = 2;
+  const amountOfPages = Math.ceil(mockData.length / itemsPerPage);
+
+  const onPrevClick = () => {
+    setCurrentPage(currentPage - 1);
+  };
+
+  const onNextClick = () => {
+    setCurrentPage(currentPage + 1);
+  };
+
+  const onDropdownSelect = (selectedPage) => {
+    setCurrentPage(selectedPage);
+  };
+
+  const isInRange = (blogpostIndex) => {
+    const currentRange = [
+      currentPage * itemsPerPage - 2,
+      currentPage * itemsPerPage - 1,
+    ];
+    return currentRange.includes(blogpostIndex);
+  };
+
+  return (
+    <div>
+      {mockData.map((blogpost, index) => {
+        if (isInRange(index)) {
+          return <p>{blogpost}</p>;
+        }
+      })}
+      <Pagination
+        amountOfPages={amountOfPages}
+        currentPage={currentPage}
+        onNextClick={onNextClick}
+        onPreviousClick={onPrevClick}
+        onDropdownSelect={onDropdownSelect}
+      />
+    </div>
+  );
+};
+
+export const WithMockData = ComponentWithPagination.bind({});

--- a/src/components/pagination/pagination.stories.tsx
+++ b/src/components/pagination/pagination.stories.tsx
@@ -25,11 +25,11 @@ Regular.args = {
   onDropdownSelect: (selectedPage) => {
     return selectedPage;
   },
-  currentPage: 1,
+  currentPage: 0,
 };
 
 const ComponentWithPagination = () => {
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
 
   const mockData = [
     'Blogpost: 1',
@@ -60,8 +60,8 @@ const ComponentWithPagination = () => {
 
   const isInRange = (blogpostIndex) => {
     const currentRange = [
-      currentPage * itemsPerPage - 2,
-      currentPage * itemsPerPage - 1,
+      (currentPage + 1) * itemsPerPage - 2,
+      (currentPage + 1) * itemsPerPage - 1,
     ];
     return currentRange.includes(blogpostIndex);
   };
@@ -70,7 +70,7 @@ const ComponentWithPagination = () => {
     <div>
       {mockData.map((blogpost, index) => {
         if (isInRange(index)) {
-          return <p>{blogpost}</p>;
+          return <p key={blogpost}>{blogpost}</p>;
         }
       })}
       <Pagination

--- a/src/components/pagination/pagination.stories.tsx
+++ b/src/components/pagination/pagination.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Pagination } from './pagination';
+
+export default {
+  component: Pagination,
+  title: 'Components/Pagination',
+  parameters: {},
+  argTypes: {},
+} as ComponentMeta<typeof Pagination>;
+
+const Template: ComponentStory<typeof Pagination> = (args) => (
+  <Pagination {...args} />
+);
+
+export const Regular = Template.bind({});
+Regular.args = {};

--- a/src/components/pagination/pagination.stories.tsx
+++ b/src/components/pagination/pagination.stories.tsx
@@ -14,4 +14,15 @@ const Template: ComponentStory<typeof Pagination> = (args) => (
 );
 
 export const Regular = Template.bind({});
-Regular.args = {};
+Regular.args = {
+  amountOfPages: 3,
+  onNextClick: () => {
+    return;
+  },
+  onPreviousClick: () => {
+    return;
+  },
+  onDropdownSelect: (selectedPage) => {
+    return selectedPage;
+  },
+};

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { PrevArrow } from '../icons/buttons-icons/prev-arrow';
 import { NextArrow } from '../icons/buttons-icons/next-arrow';
 import { theme } from '../layout/theme';
-import { PaginationDropdown } from '../typography/typography';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { TextStyles } from '../typography/typography-v2';
 
 interface PaginationProps {
   onPreviousClick: () => any;
@@ -20,7 +20,8 @@ const PaginationContainer = styled.div`
   justify-content: space-between;
 `;
 
-const Dropdown = styled(PaginationDropdown)`
+const Dropdown = styled.select`
+  ${TextStyles.toplineR}
   background: none;
   border: none;
   color: ${theme.palette.text.link.default};

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -4,6 +4,7 @@ import { PrevArrow } from '../icons/buttons-icons/prev-arrow';
 import { NextArrow } from '../icons/buttons-icons/next-arrow';
 import { theme } from '../layout/theme';
 import { PaginationDropdown } from '../typography/typography';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 interface PaginationProps {
   onPreviousClick: () => any;
@@ -53,10 +54,11 @@ export const Pagination: React.FC<PaginationProps> = ({
   onDropdownSelect,
 }: PaginationProps) => {
   const [currentPage, setCurrentPage] = useState(1);
-  const options: JSX.Element[] = [];
+  const { t } = useTranslation();
 
+  const options: JSX.Element[] = [];
   for (let i = 1; i <= amountOfPages; i++) {
-    options.push(<option value={i}>Page {i}</option>);
+    options.push(<option value={i}>{`${t('blog.pagination')} ${i}`}</option>);
   }
 
   const handlePreviousClick = () => {

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -28,14 +28,20 @@ const Dropdown = styled(PaginationDropdown)`
 `;
 
 const StyledButton = styled.button`
-  background: none;
+  padding: 14px 12px;
   border: none;
-  padding: 0;
+  background: linear-gradient(275.41deg, #543fd7 0%, #2756fd 100%);
+  border-radius: 30px;
   cursor: pointer;
+  display: flex;
 
   &:disabled {
     opacity: 50%;
     cursor: default;
+  }
+
+  &:hover:enabled {
+    background: ${theme.palette.text.link.default};
   }
 `;
 
@@ -48,10 +54,13 @@ export const Pagination = ({
 }: PaginationProps): JSX.Element => {
   const { t } = useTranslation();
 
-  const options: JSX.Element[] = [];
-  for (let i = 1; i <= amountOfPages; i++) {
-    options.push(<option value={i}>{`${t('blog.pagination')} ${i}`}</option>);
-  }
+  const options = new Array(amountOfPages)
+    .fill(null)
+    .map((_, index) => (
+      <option key={index} value={index}>{`${t('blog.pagination')} ${
+        index + 1
+      }`}</option>
+    ));
 
   const handleDropdownChange = (event) => {
     const selectedPage = parseInt(event.target.value);
@@ -60,7 +69,7 @@ export const Pagination = ({
 
   return (
     <PaginationContainer>
-      <StyledButton onClick={onPreviousClick} disabled={currentPage == 1}>
+      <StyledButton onClick={onPreviousClick} disabled={currentPage === 0}>
         <PrevArrow />
       </StyledButton>
       <Dropdown onChange={handleDropdownChange} value={currentPage}>
@@ -68,7 +77,7 @@ export const Pagination = ({
       </Dropdown>
       <StyledButton
         onClick={onNextClick}
-        disabled={currentPage == amountOfPages}
+        disabled={currentPage + 1 === amountOfPages}
       >
         <NextArrow />
       </StyledButton>

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { PrevArrow } from '../icons/buttons-icons/prev-arrow';
 import { NextArrow } from '../icons/buttons-icons/next-arrow';
 import { theme } from '../layout/theme';
@@ -27,45 +27,31 @@ const Dropdown = styled(PaginationDropdown)`
   cursor: pointer;
 `;
 
-const StyledButton = styled.button<{ inactive: boolean }>`
+const StyledButton = styled.button`
   background: none;
   border: none;
   padding: 0;
   cursor: pointer;
 
-  ${(props) =>
-    props.inactive &&
-    css`
-      cursor: default;
-      opacity: 50%;
-    `}
+  &:disabled {
+    opacity: 50%;
+    cursor: default;
+  }
 `;
 
-export const Pagination: React.FC<PaginationProps> = ({
+export const Pagination = ({
   onPreviousClick,
   onNextClick,
   amountOfPages,
   onDropdownSelect,
   currentPage,
-}: PaginationProps) => {
+}: PaginationProps): JSX.Element => {
   const { t } = useTranslation();
 
   const options: JSX.Element[] = [];
   for (let i = 1; i <= amountOfPages; i++) {
     options.push(<option value={i}>{`${t('blog.pagination')} ${i}`}</option>);
   }
-
-  const handlePreviousClick = () => {
-    if (currentPage > 1) {
-      onPreviousClick();
-    }
-  };
-
-  const handleNextClick = () => {
-    if (currentPage < amountOfPages) {
-      onNextClick();
-    }
-  };
 
   const handleDropdownChange = (event) => {
     const selectedPage = parseInt(event.target.value);
@@ -74,15 +60,15 @@ export const Pagination: React.FC<PaginationProps> = ({
 
   return (
     <PaginationContainer>
-      <StyledButton onClick={handlePreviousClick} inactive={currentPage == 1}>
+      <StyledButton onClick={onPreviousClick} disabled={currentPage == 1}>
         <PrevArrow />
       </StyledButton>
       <Dropdown onChange={handleDropdownChange} value={currentPage}>
         {options}
       </Dropdown>
       <StyledButton
-        onClick={handleNextClick}
-        inactive={currentPage == amountOfPages}
+        onClick={onNextClick}
+        disabled={currentPage == amountOfPages}
       >
         <NextArrow />
       </StyledButton>

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { PrevArrow } from '../icons/buttons-icons/prev-arrow';
+import { NextArrow } from '../icons/buttons-icons/next-arrow';
+import { theme } from '../layout/theme';
+import { PaginationDropdown } from '../typography/typography';
+
+interface PaginationProps {
+  onPreviousClick: () => any;
+  onNextClick: () => any;
+  onDropdownSelect: (selectedPage: number) => any;
+  amountOfPages: number;
+}
+
+const PaginationContainer = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-areas: 'previous dropdown next';
+`;
+
+const Dropdown = styled(PaginationDropdown)`
+  background: none;
+  border: none;
+  color: ${theme.palette.text.link.default};
+  cursor: pointer;
+
+  grid-area: dropdown;
+  justify-self: center;
+`;
+
+const Button = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+`;
+
+const PreviousButton = styled(Button)`
+  grid-area: previous;
+  justify-self: start;
+`;
+
+const NextButton = styled(Button)`
+  grid-area: next;
+  justify-self: end;
+`;
+
+export const Pagination: React.FC<PaginationProps> = ({
+  onPreviousClick,
+  onNextClick,
+  amountOfPages,
+  onDropdownSelect,
+}: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const options: JSX.Element[] = [];
+
+  for (let i = 1; i <= amountOfPages; i++) {
+    options.push(<option value={i}>Page {i}</option>);
+  }
+
+  const handlePreviousClick = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+      onPreviousClick();
+    }
+  };
+
+  const handleNextClick = () => {
+    if (currentPage < amountOfPages) {
+      setCurrentPage(currentPage + 1);
+      onNextClick();
+    }
+  };
+
+  const handleDropdownChange = (event) => {
+    const selectedPage = parseInt(event.target.value);
+    setCurrentPage(selectedPage);
+    onDropdownSelect(selectedPage);
+  };
+
+  return (
+    <PaginationContainer>
+      {currentPage !== 1 && (
+        <PreviousButton onClick={handlePreviousClick}>
+          <PrevArrow />
+        </PreviousButton>
+      )}
+      <Dropdown onChange={handleDropdownChange} value={currentPage}>
+        {options}
+      </Dropdown>
+      {currentPage !== amountOfPages && (
+        <NextButton onClick={handleNextClick}>
+          <NextArrow />
+        </NextButton>
+      )}
+    </PaginationContainer>
+  );
+};

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
+import React from 'react';
+import styled, { css } from 'styled-components';
 import { PrevArrow } from '../icons/buttons-icons/prev-arrow';
 import { NextArrow } from '../icons/buttons-icons/next-arrow';
 import { theme } from '../layout/theme';
@@ -11,13 +11,13 @@ interface PaginationProps {
   onNextClick: () => any;
   onDropdownSelect: (selectedPage: number) => any;
   amountOfPages: number;
+  currentPage: number;
 }
 
 const PaginationContainer = styled.div`
   width: 100%;
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-areas: 'previous dropdown next';
+  display: flex;
+  justify-content: space-between;
 `;
 
 const Dropdown = styled(PaginationDropdown)`
@@ -25,26 +25,20 @@ const Dropdown = styled(PaginationDropdown)`
   border: none;
   color: ${theme.palette.text.link.default};
   cursor: pointer;
-
-  grid-area: dropdown;
-  justify-self: center;
 `;
 
-const Button = styled.button`
+const StyledButton = styled.button<{ inactive: boolean }>`
   background: none;
   border: none;
   padding: 0;
   cursor: pointer;
-`;
 
-const PreviousButton = styled(Button)`
-  grid-area: previous;
-  justify-self: start;
-`;
-
-const NextButton = styled(Button)`
-  grid-area: next;
-  justify-self: end;
+  ${(props) =>
+    props.inactive &&
+    css`
+      cursor: default;
+      opacity: 50%;
+    `}
 `;
 
 export const Pagination: React.FC<PaginationProps> = ({
@@ -52,8 +46,8 @@ export const Pagination: React.FC<PaginationProps> = ({
   onNextClick,
   amountOfPages,
   onDropdownSelect,
+  currentPage,
 }: PaginationProps) => {
-  const [currentPage, setCurrentPage] = useState(1);
   const { t } = useTranslation();
 
   const options: JSX.Element[] = [];
@@ -63,39 +57,35 @@ export const Pagination: React.FC<PaginationProps> = ({
 
   const handlePreviousClick = () => {
     if (currentPage > 1) {
-      setCurrentPage(currentPage - 1);
       onPreviousClick();
     }
   };
 
   const handleNextClick = () => {
     if (currentPage < amountOfPages) {
-      setCurrentPage(currentPage + 1);
       onNextClick();
     }
   };
 
   const handleDropdownChange = (event) => {
     const selectedPage = parseInt(event.target.value);
-    setCurrentPage(selectedPage);
     onDropdownSelect(selectedPage);
   };
 
   return (
     <PaginationContainer>
-      {currentPage !== 1 && (
-        <PreviousButton onClick={handlePreviousClick}>
-          <PrevArrow />
-        </PreviousButton>
-      )}
+      <StyledButton onClick={handlePreviousClick} inactive={currentPage == 1}>
+        <PrevArrow />
+      </StyledButton>
       <Dropdown onChange={handleDropdownChange} value={currentPage}>
         {options}
       </Dropdown>
-      {currentPage !== amountOfPages && (
-        <NextButton onClick={handleNextClick}>
-          <NextArrow />
-        </NextButton>
-      )}
+      <StyledButton
+        onClick={handleNextClick}
+        inactive={currentPage == amountOfPages}
+      >
+        <NextArrow />
+      </StyledButton>
     </PaginationContainer>
   );
 };

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -151,7 +151,8 @@
   "blog": {
     "info": "Unsere Entwickler und Designer sprechen über die neuesten Trends und das Know-how rund um Tech, insbesondere über unsere neuesten Erkenntnisse und Einsichten zur Entwicklung guter Software für das Web.\n\n Der Blog ist nur auf Englisch verfügbar.",
     "share": "Artikel teilen",
-    "follow": "Blog abonnieren"
+    "follow": "Blog abonnieren",
+    "pagination": "Seite"
   },
   "blogpost": {
     "leadbox": {

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -151,7 +151,8 @@
   "blog": {
     "info": "Our developers and designers talk about the latest trends and know-how around tech, especially about our latest learnings and insights on creating good software for the web.",
     "share": "Share article",
-    "follow": "Follow blog"
+    "follow": "Follow blog",
+    "pagination": "Page"
   },
   "blogpost": {
     "leadbox": {


### PR DESCRIPTION
Resolves https://github.com/satellytes/satellytes.com/issues/170
Storybook: https://deploy-preview-191--satellytes-website-storybook.netlify.app

## What's included?
- new Pagination component (is currently only used in the blog overview)

## Technical thoughts
Before implementing the component, I discussed a few technical details with Fabian. I would be happy to hear more opinions about it. 

**Should the pagination change the URL?**
- The advantage of this would be that not all blogpost teasers have to be loaded, but only those that are currently displayed. But this is rather irrelevant because the number of blogposts is small.
When a new blog post is added, all other blogposts move to another page. This may cause problems with the Google preview. That's why we decided that the pagination does not change the URL.

**Should the logic take place in the pagination component or in the parent?**
- We decided to keep the component as simple as possible and build the logic into the parent. 

## Preview
<img width="634" alt="Bildschirmfoto 2021-11-18 um 17 22 33" src="https://user-images.githubusercontent.com/57712895/142455023-9ed4e364-60d5-48bd-88f5-57f4a0cb99d8.png">


