### PR TITLE
fix: add useEffect to update transparent prop (header)

### DIFF
--- a/src/components/header/header.stories.tsx
+++ b/src/components/header/header.stories.tsx
@@ -17,17 +17,5 @@ Regular.args = {
   siteTitle: 'Satellytes',
   $lightTheme: false,
   showLanguageSwitch: true,
-};
-
-export const WithLightTheme = Template.bind({});
-WithLightTheme.args = {
-  ...Regular.args,
-  $lightTheme: true,
-};
-
-export const WithLightThemeTransparent = Template.bind({});
-WithLightThemeTransparent.args = {
-  ...Regular.args,
-  $lightTheme: true,
-  transparent: true,
+  transparent: false,
 };

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -135,6 +135,12 @@ const Header: React.FC<HeaderProps> = (props) => {
   );
   const [hoverWithTransition, setHoverWithTransition] = useState(true);
 
+  const transparent = Boolean(props.transparent);
+
+  useEffect(() => {
+    setIsHeaderTransparent(transparent);
+  }, [transparent]);
+
   useEffect(() => {
     const onScroll = (): void => {
       if (props.transparent) {


### PR DESCRIPTION
Solves problems that came up in this PR: https://github.com/satellytes/satellytes.com/pull/159#discussion_r752152192

### What's included?
- add a useEffect() hook in the header component to update style when `transparent` prop changes
- remove unnecessary stories from header because all design cases are available via storybook controls 