### PR TITLE
fix: add header object to theme

### DIFF
--- a/src/@types/styled-components.d.ts
+++ b/src/@types/styled-components.d.ts
@@ -20,9 +20,11 @@ declare module 'styled-components' {
         defaultLight: string;
         defaultDark: string;
         secondary: string;
-        header: string;
-        headerLight: string;
-        headerHover: string;
+        header: {
+          default: string;
+          light: string;
+          hover: string;
+        };
         breadcrumb: string;
         link: {
           default: string;

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -63,12 +63,12 @@ const SiteTitle = styled(Link)<{ $lightTheme: boolean }>`
 
   color: ${(props) =>
     props.$lightTheme
-      ? props.theme.palette.text.headerLight
-      : props.theme.palette.text.header};
+      ? props.theme.palette.text.header.light
+      : props.theme.palette.text.header.default};
 
   &:hover {
     color: ${(props) =>
-      !props.$lightTheme && props.theme.palette.text.headerHover};
+      !props.$lightTheme && props.theme.palette.text.header.hover};
   }
 `;
 
@@ -95,20 +95,20 @@ const SiteMenu = styled.button<{ $lightTheme: boolean }>`
     background-color: ${(props) =>
       props.$lightTheme
         ? props.theme.palette.text.default
-        : props.theme.palette.text.header};
+        : props.theme.palette.text.header.default};
   }
 
   rect {
     fill: ${(props) =>
       props.$lightTheme
-        ? props.theme.palette.text.headerLight
-        : props.theme.palette.text.header};
+        ? props.theme.palette.text.header.light
+        : props.theme.palette.text.header.default};
   }
 
   &:hover {
     .bar {
       background-color: ${(props) =>
-        !props.$lightTheme && props.theme.palette.text.headerHover};
+        !props.$lightTheme && props.theme.palette.text.header.hover};
     }
   }
 `;

--- a/src/components/language-switch/language-switch.tsx
+++ b/src/components/language-switch/language-switch.tsx
@@ -22,7 +22,7 @@ const getTextColor = ({
   if (fromNavigation || $lightTheme) {
     return theme.palette.text.default;
   } else {
-    return theme.palette.text.header;
+    return theme.palette.text.header.default;
   }
 };
 
@@ -36,9 +36,9 @@ const getTextHoverColor = ({
   theme: DefaultTheme;
 }) => {
   if (fromNavigation) {
-    return theme.palette.text.header;
+    return theme.palette.text.header.default;
   } else if (!$lightTheme) {
-    return theme.palette.text.headerHover;
+    return theme.palette.text.header.hover;
   }
 };
 

--- a/src/components/layout/theme.tsx
+++ b/src/components/layout/theme.tsx
@@ -10,9 +10,11 @@ export const theme: DefaultTheme = {
       defaultLight: '#FFFFFF',
       defaultDark: '#FFFFFF',
       secondary: 'rgba(32,40,64,0.5)',
-      header: '#FFFFFF',
-      headerLight: '#668CFF',
-      headerHover: '#3E61EE',
+      header: {
+        default: '#FFFFFF',
+        light: '#668CFF',
+        hover: '#3E61EE',
+      },
       breadcrumb: 'rgba(0, 0, 0, 0.5)',
       link: {
         default: '#3E61EE',


### PR DESCRIPTION
Solves problems that came up in https://github.com/satellytes/satellytes.com/pull/159#discussion_r752155948

### What's included?
- In theme.tsx `header`, `headerLight` and `headerHover` is moved in to a new `header` object