### PR TITLE
refactoring(Teaser): remove StyledTeaserTitle

### DIFF
--- a/src/components/teasers/teaser.tsx
+++ b/src/components/teasers/teaser.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import {
   TeaserTitle,
-  TeaserTitleLarge,
   Text,
   Timestamp,
   Topline,
@@ -47,8 +46,18 @@ const TeaserText = styled(Text)`
   margin: 16px 0 22px;
 `;
 
-const StyledTeaserTitle = styled(TeaserTitle)<{ hasTopline: boolean }>`
+const StyledTeaserTitle = styled(TeaserTitle)<{
+  hasTopline: boolean;
+  large: boolean;
+}>`
   margin-top: ${(props) => (props.hasTopline ? '8px' : '24px')};
+
+  ${(props) =>
+    props.large &&
+    css`
+      margin-top: 20px;
+      font-size: 28px;
+    `}
 `;
 
 const CoverContainer = styled.div`
@@ -88,13 +97,9 @@ export const Teaser: React.FC<TeaserProps> = ({
             {dateFormatted && <Timestamp>{dateFormatted}</Timestamp>}
           </ToplineContainer>
         )}
-        {cover ? (
-          <StyledTeaserTitle hasTopline={hasToplineContainer}>
-            {title}
-          </StyledTeaserTitle>
-        ) : (
-          <TeaserTitleLarge>{title}</TeaserTitleLarge>
-        )}
+        <StyledTeaserTitle hasTopline={hasToplineContainer} large={!cover}>
+          {title}
+        </StyledTeaserTitle>
         <TeaserText>{children}</TeaserText>
         <Arrow />
       </Link>

--- a/src/components/typography/typography.tsx
+++ b/src/components/typography/typography.tsx
@@ -159,14 +159,6 @@ export const Timestamp = styled.p`
 /**
  * Teaser
  */
-export const TeaserTitleLarge = styled.p`
-  font-weight: bold;
-  font-size: 28px;
-  line-height: 110%;
-  margin-bottom: 8px;
-  margin-top: 20px;
-`;
-
 export const TeaserTitle = styled.p`
   font-weight: bold;
   font-size: 20px;


### PR DESCRIPTION
**What's included?**
- Pass a prop called `large` to `StyledTeaserTitle` instead of using two different titles (`StyledTeaserTitle` & `TeaserTitleLarge`)