### PR TITLE
feat: add teaser overview story

### DIFF
--- a/src/components/teasers/teaser.stories.mdx
+++ b/src/components/teasers/teaser.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { Teaser } from './teaser';
-import {Regular, WithImage, WithIllustration} from './teaser.stories'
+import {Regular, WithImage, WithIllustration, TeaserGrid} from './teaser.stories'
 
 
 <Meta title="Components/Teaser" component={Teaser} />
@@ -27,4 +27,9 @@ A short overview with all variants of the teaser that are currently included in 
 #### With Illustration
 <Canvas>
   <Story story={WithIllustration}/>
+</Canvas>
+
+### With CSS Grid
+<Canvas>
+  <Story story={TeaserGrid}/>
 </Canvas>

--- a/src/components/teasers/teaser.stories.tsx
+++ b/src/components/teasers/teaser.stories.tsx
@@ -11,7 +11,7 @@ const Template: ComponentStory<typeof Teaser> = (args) => <Teaser {...args} />;
 
 export const Regular = Template.bind({});
 Regular.args = {
-  title: 'Leadbox Title',
+  title: 'Teaser Title',
   children:
     'Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Maecenas sed diam eget risus varius blandit sit amet non magna.',
   linkTo: '/blog',

--- a/src/components/teasers/teaser.stories.tsx
+++ b/src/components/teasers/teaser.stories.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { ComponentStory } from '@storybook/react';
-import { Teaser } from './teaser';
+import { Teaser, TeaserProps } from './teaser';
 import ExampleImage from '../../../blog-posts/images/angular.png';
 import styled from 'styled-components';
 import { Illustration, IllustrationSize } from '../illustration/illustration';
 import { ILLUSTRATION_NAMES } from '../illustration/illustration-set';
+import { Grid, GridItem } from '../grid/grid';
 
 const Template: ComponentStory<typeof Teaser> = (args) => <Teaser {...args} />;
 
@@ -49,4 +50,60 @@ WithImage.args = {
   topline: 'Topline',
   dateFormatted: '15th November 2021',
   cover: <SampleImage src={ExampleImage} alt="" />,
+};
+WithImage.parameters = {
+  controls: { exclude: ['cover'] },
+};
+
+const StyledGrid = styled(Grid)`
+  row-gap: 30px;
+`;
+
+interface TeaserGridTemplateProps {
+  amountOfTeasers: number;
+  teaserType: 'Regular' | 'WithImage' | 'WithIllustration';
+}
+
+const TeaserGridTemplate = ({
+  amountOfTeasers,
+  teaserType,
+}: TeaserGridTemplateProps) => {
+  const teaser =
+    teaserType === 'WithImage' ? (
+      <WithImage {...(WithImage.args as TeaserProps)} />
+    ) : teaserType === 'WithIllustration' ? (
+      <WithIllustration {...(WithIllustration.args as TeaserProps)} />
+    ) : (
+      <Regular {...(Regular.args as TeaserProps)} />
+    );
+  const teasers: JSX.Element[] = [];
+
+  for (let i = 0; i < amountOfTeasers; i++) {
+    teasers.push(
+      <GridItem sm={6} md={4}>
+        {teaser}
+      </GridItem>,
+    );
+  }
+
+  return <StyledGrid>{teasers}</StyledGrid>;
+};
+
+export const TeaserGrid = TeaserGridTemplate.bind({}) as any;
+TeaserGrid.args = {
+  amountOfTeasers: 10,
+  teaserType: 'Regular',
+};
+TeaserGrid.argTypes = {
+  teaserType: {
+    control: {
+      type: 'select',
+      options: ['Regular', 'WithImage', 'WithIllustration'],
+    },
+  },
+};
+TeaserGrid.parameters = {
+  controls: {
+    exclude: ['title', 'topline', 'dateFormatted', 'cover', 'linkTo'],
+  },
 };

--- a/src/components/teasers/teaser.tsx
+++ b/src/components/teasers/teaser.tsx
@@ -64,7 +64,7 @@ const CoverContainer = styled.div`
   overflow: hidden;
 `;
 
-interface TeaserProps {
+export interface TeaserProps {
   title: string;
   topline?: string;
   dateFormatted?: string;


### PR DESCRIPTION
Resolves issues from https://github.com/satellytes/satellytes.com/issues/173#issuecomment-975220091
Storybook URL: https://deploy-preview-198--satellytes-website-storybook.netlify.app

## What's included? 
- add a story "Teaser Grid" to showcase the natural habitat of a teaser: A grid that holds multiple instances of a teaser. 
- Teaser type (Regular, with Image or with Illustration) can be changed in the controls
- hide `cover` prop in the `WithImage` story

## Preview
<img width="1325" alt="Bildschirmfoto 2021-11-22 um 12 10 24" src="https://user-images.githubusercontent.com/57712895/142851465-b1aafc13-8685-4f53-bf2e-1f1fab64d03a.png">
