### PR TITLE
feat: build storybook on netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+storybook-static

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ yarn storybook
 yarn build-storybook
 ```
 
+The `main` branch automatically gets deployed to https://satellytes-website-storybook.netlify.app. Pull Requests on 
+Github will also be updated with a separate deployment URL.
+
 ## Writing a blog post
 
 You can add a blog post by adding a single markdown file. The markdown file contains the blog post itself and 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn storybook
 yarn build-storybook
 ```
 
-The `main` branch automatically gets deployed to https://satellytes-website-storybook.netlify.app. Pull Requests on 
+The storybook for the `main` branch automatically gets deployed to https://satellytes-website-storybook.netlify.app. Pull Requests on 
 Github will also be updated with a separate deployment URL.
 
 ## Writing a blog post


### PR DESCRIPTION
I added a build pipeline for Storybook on our Netlify account. Storybook should be built with every pull request now. The link will be posted as comment into the PR, like Gatsby Cloud also does.

The `storybook-static` folder is now included in the `.gitignore`. The files there should never be commited.