### PR TITLE
fix: use correct css value and non-null check

### DIFF
--- a/src/components/hero-image/hero-image.tsx
+++ b/src/components/hero-image/hero-image.tsx
@@ -4,14 +4,14 @@ import React from 'react';
 
 const ImageWide = styled(GatsbyImage)`
   display: block;
-  @media (max-aspect-ratio: 0.75) {
+  @media (max-aspect-ratio: 3/4) {
     display: none;
   }
 `;
 
 const ImageTall = styled(GatsbyImage)`
   display: none;
-  @media (max-aspect-ratio: 0.75) {
+  @media (max-aspect-ratio: 3/4) {
     display: block;
   }
 `;

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -110,8 +110,8 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
   const heroImage = (
     <HeroImage
       attribution={attribution}
-      wideImage={getImage(featuredImage)!}
-      squareImage={getImage(featuredImageSquared)!}
+      wideImage={getImage(featuredImage)}
+      squareImage={getImage(featuredImageSquared)}
     />
   );
   const leadbox: LeadboxProps = {


### PR DESCRIPTION
This fix fixes 2 things:
1. The annoying assertion warning under the files tab on every pull requests <img width="1530" alt="Screenshot 2021-11-24 at 14 58 22" src="https://user-images.githubusercontent.com/7814926/143252211-1cdf35ac-e415-49c2-9135-188637b1c1cf.png">
2. My editor told me that the `max-aspect-ratio` value is wrong, so I fixed it according to the CSS docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/aspect-ratio 

