### PR TITLE
feat: add custom title to storybook

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,5 +1,5 @@
 import { addons } from '@storybook/addons';
-import customTheme from './theme';
+import { customTheme } from './theme';
 
 addons.setConfig({
   theme: customTheme,

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons';
+import customTheme from './theme';
+
+addons.setConfig({
+  theme: customTheme,
+});

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,6 +1,6 @@
 import { create } from '@storybook/theming';
 
-export default create({
+export const customTheme = create({
   base: 'light',
   brandTitle: 'Satellytes UI',
 });

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,0 +1,6 @@
+import { create } from '@storybook/theming';
+
+export default create({
+  base: 'light',
+  brandTitle: 'Satellytes UI',
+});


### PR DESCRIPTION
Just a little bit of customization. The best name I could imagine was "Satellytes UI", feel free to propose something else.

I first checked how WFP is doing it: They have a custom React component to display different styles and a dynamic version number with a dropdown. They then have a somehow hacky webpack call to replace the official logo component with theirs: https://github.com/wfp/designsystem/blob/master/.storybook/main.js#L39-L45

After fiddling out with that I decided to Google the problem, as it felt too hacky to change a simple title. I then found out that there is a theming object where you can just set the title 😄  