### PR TITLE
fix: add border to quote CB

### DIFF
--- a/src/components/quote/quote.tsx
+++ b/src/components/quote/quote.tsx
@@ -12,7 +12,7 @@ const QuoteText = styled.blockquote`
   color: ${theme.palette.text.topline};
   padding-left: 20px;
   margin: 0;
-  box-shadow: inset 2px 0 0 ${theme.palette.text.topline};
+  border-left: 2px solid ${theme.palette.text.topline};
 `;
 
 export const Quote = ({ children }: QuoteProps) => {

--- a/src/components/quote/quote.tsx
+++ b/src/components/quote/quote.tsx
@@ -12,6 +12,7 @@ const QuoteText = styled.blockquote`
   color: ${theme.palette.text.topline};
   padding-left: 20px;
   margin: 0;
+  box-shadow: inset 2px 0 0 ${theme.palette.text.topline};
 `;
 
 export const Quote = ({ children }: QuoteProps) => {


### PR DESCRIPTION
Resolves: https://github.com/satellytes/satellytes.com/pull/216#issuecomment-981675981
Storybook: https://deploy-preview-226--satellytes-website-storybook.netlify.app/?path=/docs/components-quote

### What's included?
- A border was added to the Quote content block on the left side with `box-shadow`

### Preview
<img width="965" alt="Bildschirmfoto 2021-11-29 um 15 42 05" src="https://user-images.githubusercontent.com/57712895/143888034-e6bd1372-f8c1-47de-bfb9-63a9efccb5cb.png">

