### PR TITLE
feat: update career page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@ const {
 const { createBlogPosts } = require('./gatsby/create-pages/create-blog-posts');
 const {
   createCareerDetails,
-} = require('./gatsby/create-pages/create-carrer-details');
+} = require('./gatsby/create-pages/create-career-details');
 const { createFilePath } = require('gatsby-source-filesystem');
 
 exports.onCreateNode = (gatsbyCreateNodeArgs) => {

--- a/gatsby/create-pages/create-career-details.js
+++ b/gatsby/create-pages/create-career-details.js
@@ -44,13 +44,10 @@ const createCareerDetails = async ({ actions }) => {
       const jobsXml = await jobsXmlResponse.data;
 
       const xmlParser = new XMLParser({
-        tagValueProcessor: (tag, value) => {
-          return decode(value);
-        },
+        tagValueProcessor: (_, value) => decode(value),
       });
       const jobsParse = xmlParser.parse(jobsXml);
       const positions = jobsParse['workzag-jobs'].position;
-
       return { positions, languageKey };
     },
   );

--- a/gatsby/create-pages/create-carrer-details.js
+++ b/gatsby/create-pages/create-carrer-details.js
@@ -44,10 +44,13 @@ const createCareerDetails = async ({ actions }) => {
       const jobsXml = await jobsXmlResponse.data;
 
       const xmlParser = new XMLParser({
-        tagValueProcessor: (a) => decode(a), // &#039; -> '
+        tagValueProcessor: (tag, value) => {
+          return decode(value);
+        },
       });
       const jobsParse = xmlParser.parse(jobsXml);
       const positions = jobsParse['workzag-jobs'].position;
+
       return { positions, languageKey };
     },
   );

--- a/src/@types/personio.d.ts
+++ b/src/@types/personio.d.ts
@@ -1,0 +1,22 @@
+export interface PersonioJobNameValue {
+  name: string;
+  value: string;
+}
+
+export interface PersonioJobPosition {
+  id: string;
+  office: string;
+  department: string;
+  name: string;
+  jobDescriptions: {
+    jobDescription: PersonioJobNameValue[];
+  };
+  employmentType: string;
+  seniority: string;
+  schedule: string;
+  // comma separated
+  keywords: string;
+
+  satellytesPath: string;
+  satellytesShortDescription: string;
+}

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -52,6 +52,7 @@ const PanelContainer = styled.div`
 
 const PanelIllustration = styled(Illustration)`
   padding-right: 1em;
+  box-sizing: content-box;
   float: left;
 
   ${up('sm')} {

--- a/src/components/teasers/teaser.tsx
+++ b/src/components/teasers/teaser.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import {
-  TeaserTitle,
-  Text,
-  Timestamp,
-  Topline,
-} from '../typography/typography';
+import { TeaserTitle, Timestamp, Topline } from '../typography/typography';
 import { Arrow } from '../icons/arrow';
 import { theme } from '../layout/theme';
 import { Link } from '../links/links';

--- a/src/components/teasers/teaser.tsx
+++ b/src/components/teasers/teaser.tsx
@@ -42,7 +42,9 @@ const ToplineContainer = styled.div`
   justify-content: space-between;
 `;
 
-const TeaserText = styled(Text)`
+const TeaserText = styled.div`
+  font-size: 16px;
+  line-height: 150%;
   margin: 16px 0 22px;
 `;
 
@@ -69,7 +71,7 @@ export interface TeaserProps {
   topline?: string;
   dateFormatted?: string;
   cover?: JSX.Element;
-  linkTo: string;
+  linkTo?: string;
 }
 
 /**
@@ -77,6 +79,15 @@ export interface TeaserProps {
  * This requires a headline, the path to the page (linkTo) and a short text, which is entered as a child.
  * In addition, an illustration or an image, a formatted date and a topline can be displayed.
  */
+
+const ConditionalLink = ({ to, children }) => {
+  if (to) {
+    return <Link to={to}>{children}</Link>;
+  }
+
+  return children;
+};
+
 export const Teaser: React.FC<TeaserProps> = ({
   topline,
   title,
@@ -89,7 +100,7 @@ export const Teaser: React.FC<TeaserProps> = ({
 
   return (
     <TeaserContainer>
-      <Link to={linkTo}>
+      <ConditionalLink to={linkTo}>
         {cover && <CoverContainer>{cover}</CoverContainer>}
         {hasToplineContainer && (
           <ToplineContainer>
@@ -101,8 +112,8 @@ export const Teaser: React.FC<TeaserProps> = ({
           {title}
         </StyledTeaserTitle>
         <TeaserText>{children}</TeaserText>
-        <Arrow />
-      </Link>
+        {linkTo && <Arrow />}
+      </ConditionalLink>
     </TeaserContainer>
   );
 };

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -3,7 +3,6 @@ import {
   Accordion,
   AccordionSection,
 } from '../../components/accordion/accordion';
-import { TextStyles } from '../../components/typography/typography-v2';
 import styled from 'styled-components';
 import { SectionHeader } from '../../new-components/section-header/section-header';
 

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -14,8 +14,8 @@ export const ApplicationProcess = () => {
   return (
     <>
       <SectionHeader headline="Bewerbungsprozess">
-        Sich auf einen Job bewerben, das kann oft frustrierend sein. Unser Team
-        hat sich deshalb etwas überlegt, was Sinn macht. Schau dir hier unsere
+        Sich auf einen Job zu bewerben kann oft frustrierend sein. Unser Team
+        hat sich deshalb etwas überlegt was Sinn macht. Schau dir hier unsere
         vier Schritte deiner Bewerbung an.
       </SectionHeader>
 
@@ -39,13 +39,13 @@ export const ApplicationProcess = () => {
         >
           Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem
           ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen
-          Kollegen mit dir sprechen. Darüber wie du zum Programmieren gekommen
-          bist und was dich antreibt. Danach werden werden wir dich besser
+          Kollegen mit dir sprechen und wir reden darüber wie du zum Programmieren gekommen
+          bist und was dich antreibt. Danach werden wir dich besser
           kennen und du kennst die ersten Gesichter hinter Satellytes.
         </AccordionSection>
 
         <AccordionSection title="3. Technisches Interview">
-          Wir machen keine keine Whiteboard Interviews, noch schicken wir die
+          Wir machen weder Whiteboard Interviews, noch schicken wir die
           irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code
           Review durchführen, die wir dann zusammen im Interview durchsprechen.
           Hier werden sich ganz automatische spannende Gespräch ergeben. Wir
@@ -56,9 +56,9 @@ export const ApplicationProcess = () => {
         </AccordionSection>
 
         <AccordionSection title="4. Entscheidung">
-          Du kennst Du hast gezeigt was du kannst und wie du arbeitest. Wir
+          Du hast gezeigt was du kannst und wie du arbeitest. Wir
           haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt
-          lassen wir es dir wissen. Passt etwas nicht, dann lassen wir das dich
+          lassen wir es dich wissen. Passt etwas nicht, dann lassen wir das dich
           ebenfalls wissen.
         </AccordionSection>
       </Accordion>

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -7,12 +7,6 @@ import { TextStyles } from '../../components/typography/typography-v2';
 import styled from 'styled-components';
 import { SectionHeader } from '../../new-components/section-header/section-header';
 
-const Headline = styled.h2`
-  margin: 0;
-  ${TextStyles.headlineM}
-  margin-bottom: 16px;
-`;
-
 const Spacer = styled.div`
   margin-bottom: 48px;
 `;

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -32,7 +32,6 @@ export const ApplicationProcess = () => {
           deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab
           Account. Hast du einen Blog? Dann verweise gerne darauf.
         </AccordionSection>
-
         <AccordionSection
           title="2. Kennenlernen"
           illustration={'astronaut_015'}
@@ -43,7 +42,6 @@ export const ApplicationProcess = () => {
           bist und was dich antreibt. Danach werden wir dich besser
           kennen und du kennst die ersten Gesichter hinter Satellytes.
         </AccordionSection>
-
         <AccordionSection title="3. Technisches Interview">
           Wir machen weder Whiteboard Interviews, noch schicken wir die
           irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code
@@ -54,7 +52,6 @@ export const ApplicationProcess = () => {
           wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um
           sicherzustellen dass du dich bei uns wohl fühlst.
         </AccordionSection>
-
         <AccordionSection title="4. Entscheidung">
           Du hast gezeigt was du kannst und wie du arbeitest. Wir
           haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -32,16 +32,19 @@ export const ApplicationProcess = () => {
           deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab
           Account. Hast du einen Blog? Dann verweise gerne darauf.
         </AccordionSection>
+
         <AccordionSection
           title="2. Kennenlernen"
           illustration={'astronaut_015'}
         >
           Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem
           ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen
-          Kollegen mit dir sprechen und wir reden darüber wie du zum Programmieren gekommen
-          bist und was dich antreibt. Danach werden wir dich besser
-          kennen und du kennst die ersten Gesichter hinter Satellytes.
+          Kollegen mit dir sprechen und wir reden darüber wie du zum
+          Programmieren gekommen bist und was dich antreibt. Danach werden wir
+          dich besser kennen und du kennst die ersten Gesichter hinter
+          Satellytes.
         </AccordionSection>
+
         <AccordionSection title="3. Technisches Interview">
           Wir machen weder Whiteboard Interviews, noch schicken wir die
           irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code
@@ -52,11 +55,12 @@ export const ApplicationProcess = () => {
           wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um
           sicherzustellen dass du dich bei uns wohl fühlst.
         </AccordionSection>
+
         <AccordionSection title="4. Entscheidung">
-          Du hast gezeigt was du kannst und wie du arbeitest. Wir
-          haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt
-          lassen wir es dich wissen. Passt etwas nicht, dann lassen wir das dich
-          ebenfalls wissen.
+          Du hast gezeigt was du kannst und wie du arbeitest. Wir haben gezeigt
+          was uns antreibt und wie wir arbeiten. Wenn alles passt lassen wir es
+          dich wissen. Passt etwas nicht, dann lassen wir das dich ebenfalls
+          wissen.
         </AccordionSection>
       </Accordion>
     </>

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  Accordion,
+  AccordionSection,
+} from '../../components/accordion/accordion';
+import { TextStyles } from '../../components/typography/typography-v2';
+import styled from 'styled-components';
+import { SectionHeader } from '../../new-components/section-header/section-header';
+
+const Headline = styled.h2`
+  margin: 0;
+  ${TextStyles.headlineM}
+  margin-bottom: 16px;
+`;
+
+const Spacer = styled.div`
+  margin-bottom: 48px;
+`;
+
+export const ApplicationProcess = () => {
+  return (
+    <>
+      <SectionHeader headline="Bewerbungsprozess">
+        Sich auf einen Job bewerben, das kann oft frustrierend sein. Unser Team
+        hat sich deshalb etwas überlegt, was Sinn macht. Schau dir hier unsere
+        vier Schritte deiner Bewerbung an.
+      </SectionHeader>
+
+      <Spacer />
+
+      <Accordion defaultIndex={0}>
+        <AccordionSection
+          title="1. Bewerb dich"
+          illustration={'scientistB_007'}
+        >
+          Alles beginnt mit deiner Bewerbung. Schicke uns deinen Lebenslauf und
+          ein kleines Anschreiben, wieso du dich gerade bei uns bewirbst. In
+          deiner Bewerbung achten wir nicht auf Schulnoten sondern suchen nach
+          deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab
+          Account. Hast du einen Blog? Dann verweise gerne darauf.
+        </AccordionSection>
+
+        <AccordionSection
+          title="2. Kennenlernen"
+          illustration={'astronaut_015'}
+        >
+          Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem
+          ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen
+          Kollegen mit dir sprechen. Darüber wie du zum Programmieren gekommen
+          bist und was dich antreibt. Danach werden werden wir dich besser
+          kennen und du kennst die ersten Gesichter hinter Satellytes.
+        </AccordionSection>
+
+        <AccordionSection title="3. Technisches Interview">
+          Wir machen keine keine Whiteboard Interviews, noch schicken wir die
+          irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code
+          Review durchführen, die wir dann zusammen im Interview durchsprechen.
+          Hier werden sich ganz automatische spannende Gespräch ergeben. Wir
+          werden Probleme im Code besprechen und das ein oder andere Fachwissen
+          über relevante Technologien ansprechen. Neben der ganzen Technik haben
+          wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um
+          sicherzustellen dass du dich bei uns wohl fühlst.
+        </AccordionSection>
+
+        <AccordionSection title="4. Entscheidung">
+          Du kennst Du hast gezeigt was du kannst und wie du arbeitest. Wir
+          haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt
+          lassen wir es dir wissen. Passt etwas nicht, dann lassen wir das dich
+          ebenfalls wissen.
+        </AccordionSection>
+      </Accordion>
+    </>
+  );
+};

--- a/src/page-building/career/career-page.tsx
+++ b/src/page-building/career/career-page.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { ApplicationProcess } from './application-process';
+import { Openings } from './openings';
+import { SectionHeader } from '../../new-components/section-header/section-header';
+import styled from 'styled-components';
+import { TextStyles } from '../../components/typography/typography-v2';
+import { LayoutV2 } from '../../components/layout/layout-v2';
+import { Aurora } from '../../components/aurora/aurora';
+import { ContentBlockContainer } from '../../components/layout/content-block-container';
+import { PersonioJobPosition } from '../../@types/personio';
+import { Culture } from './culture';
+import { Perks } from './perks';
+import { LeadboxProps } from '../../new-components/leadbox/leadbox';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
+
+const Paragraph = styled.p`
+  ${TextStyles.textR}
+  & + & {
+    margin-bottom: 16px;
+  }
+`;
+
+interface CareerPageProps {
+  positions: PersonioJobPosition[];
+}
+
+export const CareerPage = ({ positions }: CareerPageProps) => {
+  const { t } = useTranslation();
+
+  const leadbox: LeadboxProps = {
+    title: t('career.leadbox.title'),
+    illustration: 'astronaut_012',
+    contact: {
+      headline: t('career.leadbox.subtitle'),
+      title: t('career.leadbox.text'),
+      email: t('career.leadbox.mail'),
+    },
+  };
+
+  return (
+    <LayoutV2
+      leadbox={leadbox}
+      transparentHeader={true}
+      light={true}
+      hero={<Aurora />}
+    >
+      <ContentBlockContainer>
+        <SectionHeader
+          kicker="Karriere bei Satellytes"
+          headline="Arbeite mit uns"
+        >
+          <Paragraph>
+            Satellytes – das sind aktuell 14 ausschließlich leidenschaftliche
+            Entwickler:innen und Designer:innen. Wir haben großen Spaß an
+            Technologie und freuen uns auf neue Herausforderungen. Dabei
+            fokussieren wir uns auf langfristige Engagements im Konzerngeschäft.
+          </Paragraph>
+          <Paragraph>
+            Neuen Aufgaben begegnen wir immer mit angemessenem Respekt. Wir
+            streben stets hochwertige und zeitgemäße Lösungen an – die Wahl der
+            Technologie ist für uns dabei sekundär.
+          </Paragraph>
+          <Paragraph>
+            Unser Büro befindet sich in einem wunderschönen Altbau im Herzen
+            Münchens, in der Sendlinger Straße, unweit der gleichnamigen
+            U-Bahn-Station. In Laufweite gibt es nicht nur dutzende Läden,
+            Cafés, Restaurants und den bekannten Viktualienmarkt, sondern auch
+            diverse kleinere und größere Parks. Sogar die Isar ist in der
+            Mittagspause fußläufig oder mit der U-Bahn in nur 3 Minuten zu
+            erreichen.
+          </Paragraph>
+        </SectionHeader>
+      </ContentBlockContainer>
+
+      <ContentBlockContainer>
+        <ApplicationProcess />
+      </ContentBlockContainer>
+
+      <ContentBlockContainer>
+        <Openings jobs={positions} />
+      </ContentBlockContainer>
+
+      <ContentBlockContainer>
+        <Culture />
+      </ContentBlockContainer>
+
+      <ContentBlockContainer>
+        <Culture />
+      </ContentBlockContainer>
+
+      <ContentBlockContainer>
+        <Perks />
+      </ContentBlockContainer>
+    </LayoutV2>
+  );
+};

--- a/src/page-building/career/career.stories.mdx
+++ b/src/page-building/career/career.stories.mdx
@@ -1,0 +1,51 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { ApplicationProcess } from './application-process'; 
+import { Perks } from './perks'; 
+import { Openings } from './openings';
+import { Culture } from './culture'; import { CareerPage } from './career-page';
+
+<Meta title="Pages/Career" component={{ Image }} />
+
+# Career
+The career page consists of various sections to guide any potential applicant towards an application.
+
+## Application Process
+
+<Canvas withSource={'open'}>
+  <Story name="ApplicationProcess">
+    <ApplicationProcess/>
+  </Story>
+</Canvas>
+
+<ArgsTable of={ApplicationProcess}/>
+
+
+## Job Openings
+<Canvas withSource={'open'}>
+  <Story name="Openings">
+    <Openings jobs={[
+      {name: "Frontend Engineer", satellytesPath: "#", satellytesShortDescription: "Come work here!"},
+      {name: "Senior Frontend Engineer", satellytesPath: "#", satellytesShortDescription: "Come work here!"},
+      {name: "Backend Engineer", satellytesPath: "#", satellytesShortDescription: "Come work here!"},
+      {name: "UX/UI", satellytesPath: "#", satellytesShortDescription: "Come work here!"}
+    ]}/>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Openings}/>
+
+## Culture
+<Canvas withSource={'open'}>
+  <Story name="Culture">
+    <Culture/>
+  </Story>
+</Canvas>
+
+
+## Perks
+<Canvas withSource={'open'}>
+  <Story name="Perks">
+    <Perks/>
+  </Story>
+</Canvas>
+

--- a/src/page-building/career/culture.tsx
+++ b/src/page-building/career/culture.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import styled from 'styled-components';
+import { up } from '../../components/breakpoint/breakpoint';
+import { Teaser } from '../../components/teasers/teaser';
+import { Illustration } from '../../components/illustration/illustration';
+import { IllustrationType } from '../../components/illustration/illustration-set';
+import { SectionHeader } from '../../new-components/section-header/section-header';
+
+interface CultureAspect {
+  illustration: IllustrationType;
+  title: string;
+  description: string;
+}
+
+const TeaserGrid = styled.div`
+  display: grid;
+  gap: 24px;
+
+  justify-items: stretch;
+  grid-template-columns: repeat(auto-fit, 250px);
+  ${up('md')} {
+    gap: 70px;
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+`;
+
+const ASPECTS: CultureAspect[] = [
+  {
+    title: 'Cross-Functional',
+    description:
+      'Teams aus Designern, Produktmanagern, Entwicklern, Supportmitarbeitern, Marketingspezialisten usw. bringen die richtige Mischung aus Know-how und Erfahrung mit und sorgen dafür, dass auch mal über den Tellerrand geschaut wird.',
+    illustration: 'radar_030',
+  },
+
+  {
+    title: 'Self-Organisation',
+    description:
+      'Jedes Team bei Satellytes ist für seine eigenen Aufgaben verantwortlich. In den Worten des Agilen Manifests: „Die besten Architekturen, Anforderungen und Entwürfe entstehen durch selbstorganisierte Teams.“',
+    illustration: 'rocket_011',
+  },
+
+  {
+    title: 'Agile',
+    description:
+      'Schnelles Feedback, kurze Entscheidungswege und Offenheit für Veränderung sind uns wichtig – egal, ob man es Scrum, Kanban oder XP nennt.',
+    illustration: 'sputnik_045',
+  },
+
+  {
+    title: 'Erfolgreich scheitern',
+    description:
+      'Wenn wir etwas Neues ausprobieren, riskieren wir immer auch einen Misserfolg. Macht nichts – aus Fehlern lernen, Erkenntnisse mit anderen teilen und im nächsten Projekt in Erfolge ummünzen.',
+    illustration: 'planets_005',
+  },
+
+  {
+    title: 'Feedback',
+    description:
+      'Zusammenarbeit ist bei uns nicht nur ein Wort: Code-Review, Inline-Kommentare, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback usw.',
+    illustration: 'report_031',
+  },
+  {
+    title: 'Open Work',
+    description:
+      'Offen sein, zuhören, andere Meinungen respektieren und gemeinsam die besten Lösungen finden.',
+    illustration: 'book_038',
+  },
+];
+
+const CultureTeaserGrid = styled(TeaserGrid)`
+  margin-top: 48px;
+`;
+
+export const Culture = () => {
+  return (
+    <>
+      <SectionHeader kicker="Team" headline="Spass an der Arbeit">
+        Wir möchten die Voraussetzung schaffen, damit sich jeder persönlich wie
+        beruflich weiterentwickeln kann.
+      </SectionHeader>
+
+      <CultureTeaserGrid>
+        {ASPECTS.map((item, index) => (
+          <Teaser
+            title={item.title}
+            key={index}
+            cover={<Illustration show={item.illustration} />}
+          >
+            {item.description}
+          </Teaser>
+        ))}
+      </CultureTeaserGrid>
+    </>
+  );
+};

--- a/src/page-building/career/openings.tsx
+++ b/src/page-building/career/openings.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Teaser } from '../../components/teasers/teaser';
+import styled from 'styled-components';
+import { up } from '../../components/breakpoint/breakpoint';
+import { TextStyles } from '../../components/typography/typography-v2';
+import { PersonioJobPosition } from '../../@types/personio';
+
+const TeaserGrid = styled.div`
+  display: grid;
+  gap: 24px;
+
+  justify-items: stretch;
+  grid-template-columns: repeat(auto-fit, 250px);
+  ${up('md')} {
+    gap: 70px;
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+`;
+
+const SectionHeadline = styled.h2`
+  ${TextStyles.headlineXL}
+  margin: 0;
+  margin-bottom: 80px;
+`;
+
+type PersonioJobPositionPartial = Pick<
+  PersonioJobPosition,
+  'name' | 'id' | 'satellytesPath' | 'satellytesShortDescription'
+>;
+
+interface OpeningsProps {
+  jobs: PersonioJobPositionPartial[];
+}
+
+export const Openings = (props: OpeningsProps) => {
+  return (
+    <div>
+      <SectionHeadline>Unsere offenen Stellen</SectionHeadline>
+
+      <TeaserGrid>
+        {props.jobs.map((item, index) => (
+          <Teaser title={item.name} linkTo={item.satellytesPath} key={item.id}>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: item.satellytesShortDescription,
+              }}
+            />
+          </Teaser>
+        ))}
+      </TeaserGrid>
+    </div>
+  );
+};

--- a/src/page-building/career/openings.tsx
+++ b/src/page-building/career/openings.tsx
@@ -38,7 +38,7 @@ export const Openings = (props: OpeningsProps) => {
       <SectionHeadline>Unsere offenen Stellen</SectionHeadline>
 
       <TeaserGrid>
-        {props.jobs.map((item, index) => (
+        {props.jobs.map((item) => (
           <Teaser title={item.name} linkTo={item.satellytesPath} key={item.id}>
             <div
               dangerouslySetInnerHTML={{

--- a/src/page-building/career/perks.tsx
+++ b/src/page-building/career/perks.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Teaser } from '../../components/teasers/teaser';
+import { Illustration } from '../../components/illustration/illustration';
+import { up } from '../../components/breakpoint/breakpoint';
+import { IllustrationType } from '../../components/illustration/illustration-set';
+import { SectionHeader } from '../../new-components/section-header/section-header';
+
+interface Perk {
+  illustration: IllustrationType;
+}
+
+const TeaserGrid = styled.div`
+  display: grid;
+  gap: 24px;
+
+  justify-items: stretch;
+  grid-template-columns: repeat(auto-fit, 250px);
+  ${up('md')} {
+    gap: 70px;
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+`;
+
+interface Perk {
+  illustration: IllustrationType;
+  title: string;
+  description: string;
+}
+
+const PERKS: Perk[] = [
+  {
+    title: 'Zeit für Experimente',
+    description:
+      'Bei uns bekommst du Raum, um neue Technologien auszuprobieren oder mit Kollegen kleine Experimente durchzuführen',
+    illustration: 'scientistA_006',
+  },
+
+  {
+    title: 'Lebenslanges Lernen',
+    description:
+      'Du wirst bei uns jeden Tag etwas lernen, egal ob du dich als Anfänger oder Profi siehst. Sollte dir selbst mal die Muse fehlen, dann wird ein Kollege dich sicherlich kurz später zu inspirieren wissen. Und wenn du mal ein Buch brauchst: Jedes Buch geht auf uns.',
+    illustration: 'universe_003',
+  },
+
+  {
+    title: 'Lieblingsausrüstung',
+    description:
+      'Ob MacBook oder Linux Laptop? Ob Maus oder Trackpad oder VSCode oder IntelliJ. Du hast bei uns die Wahl.',
+    illustration: 'monitor_024',
+  },
+
+  {
+    title: 'Arbeiten wo du willst',
+    description:
+      'Arbeitszeit und Arbeitsort kannst du nach Absprache mit dem Team & Kunden flexibel wählen.',
+    illustration: 'galaxy_013',
+  },
+
+  {
+    title: 'Konferenzen',
+    description:
+      'Wir lieben Tech-Konferenzen und sind schon oft Besucher und manchmal sogar Speaker gewesen. Wir zahlen dir Ticket, Kost und Logis. Willst du Speaker werden? Wir unterstützen dich dabei.',
+    illustration: 'planetarium_028',
+  },
+];
+
+const PerksTeaserGrid = styled(TeaserGrid)`
+  margin-top: 48px;
+`;
+
+export const Perks = () => {
+  return (
+    <>
+      <SectionHeader kicker="Arbeiten" headline=" Perks & Benefits  ">
+        Neben einem großartigen Team, interessanten Aufgaben und einer modernen
+        Arbeitsumgebung bieten wir noch weitere Extras.
+      </SectionHeader>
+
+      <PerksTeaserGrid>
+        {PERKS.map((item, index) => (
+          <Teaser
+            title={item.title}
+            key={index}
+            cover={<Illustration show={item.illustration} />}
+          >
+            {item.description}
+          </Teaser>
+        ))}
+      </PerksTeaserGrid>
+    </>
+  );
+};

--- a/src/templates/career-details.tsx
+++ b/src/templates/career-details.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Layout from '../components/layout/layout';
 import SEO from '../components/seo';
 import { Grid, GridItem } from '../components/grid/grid';
-import { PersonioJobPosition } from './career';
+import { PersonioJobPosition } from '../@types/personio';
 import styled from 'styled-components';
 import { up } from '../components/breakpoint/breakpoint';
 import { TextTitle } from '../components/typography/typography';

--- a/src/templates/career.tsx
+++ b/src/templates/career.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import SEO from '../components/seo';
 import { graphql } from 'gatsby';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { LeadboxProps } from '../new-components/leadbox/leadbox';
 import { CareerPage } from '../page-building/career/career-page';
 import { PersonioJobPosition } from '../@types/personio';
 

--- a/src/templates/career.tsx
+++ b/src/templates/career.tsx
@@ -1,76 +1,16 @@
 import React from 'react';
-
-import Layout from '../components/layout/layout';
 import SEO from '../components/seo';
-import {
-  LargeText,
-  PageTitle,
-  SectionTitle,
-  Text,
-  TextLink,
-} from '../components/typography/typography';
-import { Grid, GridItem } from '../components/grid/grid';
 import { graphql } from 'gatsby';
-import { JobCard } from '../components/cards/job-card';
-import styled from 'styled-components';
-import { up } from '../components/breakpoint/breakpoint';
-import { Aurora, AuroraType } from '../components/aurora/aurora';
-import { MarkdownAst } from '../components/markdown/markdown-ast';
-import { Trans, useTranslation } from 'gatsby-plugin-react-i18next';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { LeadboxProps } from '../new-components/leadbox/leadbox';
-
-const PositionsTitle = styled(SectionTitle)`
-  font-size: 24px;
-  margin: 80px 0 24px 0;
-
-  ${up('md')} {
-    font-size: 32px;
-    margin: 120px 0 32px 0;
-  }
-`;
-
-const JobCardGridItem = styled(GridItem)`
-  height: 100%;
-  padding-bottom: 24px;
-`;
-
-const InfoText = styled(Text)`
-  font-size: 18px;
-  a {
-    font-size: 18px;
-  }
-
-  margin-top: 8px;
-`;
+import { CareerPage } from '../page-building/career/career-page';
+import { PersonioJobPosition } from '../@types/personio';
 
 interface CareerQuery {
   htmlAst: string;
   fields: {
     socialCard: string;
   };
-}
-
-interface PersonioJobNameValue {
-  name: string;
-  value: string;
-}
-
-export interface PersonioJobPosition {
-  id: string;
-  office: string;
-  department: string;
-  name: string;
-  jobDescriptions: {
-    jobDescription: PersonioJobNameValue[];
-  };
-  employmentType: string;
-  seniority: string;
-  schedule: string;
-  // comma separated
-  keywords: string;
-
-  satellytesPath: string;
-  satellytesShortDescription: string;
 }
 
 interface CareerPageProps {
@@ -93,71 +33,28 @@ interface CareerPageProps {
   };
 }
 
-const CareerPage = ({
+const Career = ({
   pageContext,
   data,
   location,
 }: CareerPageProps): JSX.Element => {
   const { t } = useTranslation();
-
   const socialCard = data.markdownRemark?.fields?.socialCard;
-
-  const leadboxProps: LeadboxProps = {
-    title: t('career.leadbox.title'),
-    illustration: 'astronaut_012',
-    contact: {
-      headline: t('career.leadbox.subtitle'),
-      title: t('career.leadbox.text'),
-      email: t('career.leadbox.mail'),
-    },
-  };
 
   return (
     <>
-      <Aurora type={AuroraType.Pink} />
-      <Layout transparentHeader={true} leadbox={leadboxProps}>
-        <SEO
-          imageUrl={socialCard}
-          title={t('career.seo.title')}
-          description={t('career.seo.description')}
-          location={location}
-        />
-        <Grid>
-          <GridItem>
-            <PageTitle>{t('career.title')}</PageTitle>
-          </GridItem>
-          <GridItem xs={12} md={8}>
-            <LargeText as={'h2'}>{t('career.subheading')}</LargeText>
-            <MarkdownAst htmlAst={data.markdownRemark.htmlAst} />
-            <PositionsTitle>{t('career.title-positions')}</PositionsTitle>
-          </GridItem>
-          <GridItem xs={0} md={4} />
-          {pageContext.positions.map((position) => (
-            <JobCardGridItem xs={12} sm={6} md={4} lg={3} key={position.id}>
-              <JobCard
-                title={position.name}
-                text={position.satellytesShortDescription}
-                link={position.satellytesPath}
-              />
-            </JobCardGridItem>
-          ))}
-          <GridItem xs={12}>
-            <Trans i18nKey={'career.action.alternative'}>
-              <InfoText>
-                Oder schicke deine Bewerbung an:
-                <TextLink to="mailto:career@satellytes.com">
-                  career@satellytes.com
-                </TextLink>
-              </InfoText>
-            </Trans>
-          </GridItem>
-        </Grid>
-      </Layout>
+      <SEO
+        imageUrl={socialCard}
+        title={t('career.seo.title')}
+        description={t('career.seo.description')}
+        location={location}
+      />
+      <CareerPage positions={pageContext.positions} />
     </>
   );
 };
 
-export default CareerPage;
+export default Career;
 
 export const CareerPageQuery = graphql`
   query ($language: String!) {


### PR DESCRIPTION
Let's try to run only a shallow review on this. I will work on the career page with other PRs anyway and I'm trying out a few things in terms of component organization. I'm happy to discuss and talk about things I did, this is not something I want to force. I just want to get some of the content out of my mind to focus on the rest.

---

I have walked over the career page, wrote missing texts and then created section after section. I would like to push this change to get a clean table for the next iteration: adding images that spread across the full width and into the header.


I had big problems finding a good way for the sizing and such. I also didn't want to use the `HeaderBlock` which is kind of obsolete almost (after the split of SectionHeader/Blog Header). What I did is use mostly existing components but for a few headlines or texts I created a local component. 

In the same vein I struggled with the spacing. I use the `ContentBlockContainer` but it feels not ideal but good enough. At some points I inserted a spacer to try out how it feels or I wrapped a component. 

**Important:**
I would like you to focus on technical problems or content-wise (as I wrote a few textst). Please let's ignore the spacing and the actual composition of components. My goal is to have more material with yet another page and then we can hopefully generalize a few concepts.

## Changes/Remarks
+ I had to fix the parsing of our jobs to get the jobbs
+ I decided to create a career page component and isolate it from the actual thin gatsby wrapper in `pages/`. I like how this feels because I can clearly see that the page only depends on `positions`.
+ I have not translated the texts. This is something done by some translation agency later. Rather then translating I would like to disable the English version of we keep mixed content. We should not translate ourselves.
+ I have placed the "partials" of the career page in `page-building/` as I had not better name. Ideally it would be in `components/pages` while our ui components would live in `components/ui` and such. We can do that later.
