### PR TITLE
feat: add translation keys to career page

### DIFF
--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -48,6 +48,98 @@
     "other": "anderes",
     "info-text": "Lade hier bitte deine relevanten Dokumente hoch, wie zb Lebenslauf (CV), Motivationschreiben oder Referenzen. Erlaubt sind ausschließlich 3 PDF Dateien, die maximale Größe pro Datei beträgt 20MB.",
     "privacy-policy": "<0>Hiermit bestätige ich, dass ich die <1>Datenschutzerklärung</1> zur Kenntnis genommen habe. <4>*</4></0>",
+    "introduction": {
+      "headline": "Arbeite mit uns",
+      "kicker": "Karriere bei Satellytes",
+      "paragraphs": [
+        "Satellytes – das sind aktuell 14 ausschließlich leidenschaftliche Entwickler:innen und Designer:innen. Wir haben großen Spaß an Technologie und freuen uns auf neue Herausforderungen. Dabei fokussieren wir uns auf langfristige Engagements im Konzerngeschäft.",
+        "Neuen Aufgaben begegnen wir immer mit angemessenem Respekt. Wir streben stets hochwertige und zeitgemäße Lösungen an – die Wahl der Technologie ist für uns dabei sekundär.",
+        "Unser Büro befindet sich in einem wunderschönen Altbau im Herzen Münchens, in der Sendlinger Straße, unweit der gleichnamigen U-Bahn-Station. In Laufweite gibt es nicht nur dutzende Läden, Cafés, Restaurants und den bekannten Viktualienmarkt, sondern auch diverse kleinere und größere Parks. Sogar die Isar ist in der Mittagspause fußläufig oder mit der U-Bahn in nur 3 Minuten zu erreichen."
+      ]
+    },
+    "application-process": {
+      "headline": "Bewerbungsprozess",
+      "paragraph": "Sich auf einen Job zu bewerben kann oft frustrierend sein. Unser Team hat sich deshalb etwas überlegt was Sinn macht. Schau dir hier unsere vier Schritte deiner Bewerbung an.",
+      "accordion": [
+        {
+          "title": "1. Bewerb dich",
+          "paragraph": "Alles beginnt mit deiner Bewerbung. Schicke uns deinen Lebenslauf und ein kleines Anschreiben, wieso du dich gerade bei uns bewirbst. In deiner Bewerbung achten wir nicht auf Schulnoten sondern suchen nach deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab Account. Hast du einen Blog? Dann verweise gerne darauf."
+        },
+        {
+          "title": "2. Kennenlernen",
+          "paragraph": "Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen Kollegen mit dir sprechen und wir reden darüber wie du zum Programmieren gekommen bist und was dich antreibt. Danach werden wir dich besser kennen und du kennst die ersten Gesichter hinter Satellytes."
+        },
+        {
+          "title": "3. Technisches Interview",
+          "paragraph": "Wir machen weder Whiteboard Interviews, noch schicken wir die irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code Review durchführen, die wir dann zusammen im Interview durchsprechen. Hier werden sich ganz automatische spannende Gespräch ergeben. Wir werden Probleme im Code besprechen und das ein oder andere Fachwissen über relevante Technologien ansprechen. Neben der ganzen Technik haben wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um sicherzustellen dass du dich bei uns wohl fühlst."
+        },
+        {
+          "title": "4. Entscheidung",
+          "paragraph": "Du hast gezeigt was du kannst und wie du arbeitest. Wir haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt lassen wir es dich wissen. Passt etwas nicht, dann lassen wir das dich ebenfalls wissen."
+        }
+      ]
+    },
+    "openings": {
+      "headline": "Unsere offenen Stellen"
+    },
+    "culture": {
+      "headline": "Spass an der Arbeit",
+      "kicker": "Team",
+      "paragraph": "Wir möchten die Voraussetzung schaffen, damit sich jeder persönlich wie beruflich weiterentwickeln kann.",
+      "teaser": [
+        {
+          "title": "Cross-Functional",
+          "description": "Teams aus Designern, Produktmanagern, Entwicklern, Supportmitarbeitern, Marketingspezialisten usw. bringen die richtige Mischung aus Know-how und Erfahrung mit und sorgen dafür, dass auch mal über den Tellerrand geschaut wird."
+        },
+        {
+          "title": "Self-Organisation",
+          "description": "Jedes Team bei Satellytes ist für seine eigenen Aufgaben verantwortlich. In den Worten des Agilen Manifests: „Die besten Architekturen, Anforderungen und Entwürfe entstehen durch selbstorganisierte Teams.“"
+        },
+        {
+          "title": "Agile",
+          "description": "Schnelles Feedback, kurze Entscheidungswege und Offenheit für Veränderung sind uns wichtig – egal, ob man es Scrum, Kanban oder XP nennt."
+        },
+        {
+          "title": "Erfolgreich scheitern",
+          "description": "Wenn wir etwas Neues ausprobieren, riskieren wir immer auch einen Misserfolg. Macht nichts – aus Fehlern lernen, Erkenntnisse mit anderen teilen und im nächsten Projekt in Erfolge ummünzen."
+        },
+        {
+          "title": "Feedback",
+          "description": "Zusammenarbeit ist bei uns nicht nur ein Wort: Code-Review, Inline-Kommentare, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback usw."
+        },
+        {
+          "title": "Open Work",
+          "description": "Offen sein, zuhören, andere Meinungen respektieren und gemeinsam die besten Lösungen finden."
+        }
+      ]
+    },
+    "perk": {
+      "headline": "Perks & Benefits",
+      "kicker": "Arbeiten",
+      "paragraph": "Neben einem großartigen Team, interessanten Aufgaben und einer modernen Arbeitsumgebung bieten wir noch weitere Extras.",
+      "teaser": [
+        {
+          "title": "Zeit für Experimente",
+          "description": "Bei uns bekommst du Raum, um neue Technologien auszuprobieren oder mit Kollegen kleine Experimente durchzuführen"
+        },
+        {
+          "title": "Lebenslanges Lernen",
+          "description": "Du wirst bei uns jeden Tag etwas lernen, egal ob du dich als Anfänger oder Profi siehst. Sollte dir selbst mal die Muse fehlen, dann wird ein Kollege dich sicherlich kurz später zu inspirieren wissen. Und wenn du mal ein Buch brauchst: Jedes Buch geht auf uns."
+        },
+        {
+          "title": "Lieblingsausrüstung",
+          "description": "Ob MacBook oder Linux Laptop? Ob Maus oder Trackpad oder VSCode oder IntelliJ. Du hast bei uns die Wahl."
+        },
+        {
+          "title": "Arbeiten wo du willst",
+          "description": "Arbeitszeit und Arbeitsort kannst du nach Absprache mit dem Team & Kunden flexibel wählen."
+        },
+        {
+          "title": "Konferenzen",
+          "description": "Wir lieben Tech-Konferenzen und sind schon oft Besucher und manchmal sogar Speaker gewesen. Wir zahlen dir Ticket, Kost und Logis. Willst du Speaker werden? Wir unterstützen dich dabei."
+        }
+      ]
+    },
     "error": {
       "approval": "Deine Zustimmung fehlt",
       "first-name": "Dein Vorname fehlt",

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -52,9 +52,7 @@
       "headline": "Arbeite mit uns",
       "kicker": "Karriere bei Satellytes",
       "paragraphs": [
-        "Satellytes – das sind aktuell 14 ausschließlich leidenschaftliche Entwickler:innen und Designer:innen. Wir haben großen Spaß an Technologie und freuen uns auf neue Herausforderungen. Dabei fokussieren wir uns auf langfristige Engagements im Konzerngeschäft.",
-        "Neuen Aufgaben begegnen wir immer mit angemessenem Respekt. Wir streben stets hochwertige und zeitgemäße Lösungen an – die Wahl der Technologie ist für uns dabei sekundär.",
-        "Unser Büro befindet sich in einem wunderschönen Altbau im Herzen Münchens, in der Sendlinger Straße, unweit der gleichnamigen U-Bahn-Station. In Laufweite gibt es nicht nur dutzende Läden, Cafés, Restaurants und den bekannten Viktualienmarkt, sondern auch diverse kleinere und größere Parks. Sogar die Isar ist in der Mittagspause fußläufig oder mit der U-Bahn in nur 3 Minuten zu erreichen."
+        "Wir sind Satellytes, ein Team aus sehr erfahrenen Entwicklern und einigen Designern. Wir bringen großen Unternehmen nachhaltige, barrierefreie, verlässliche und moderne Lösungen rund ums Web. Wenn du Interesse hast, bei uns mitzumachen, dann schau dir gleich unserer offenen Positionen an."
       ]
     },
     "application-process": {
@@ -92,7 +90,7 @@
           "description": "Teams aus Designern, Produktmanagern, Entwicklern, Supportmitarbeitern, Marketingspezialisten usw. bringen die richtige Mischung aus Know-how und Erfahrung mit und sorgen dafür, dass auch mal über den Tellerrand geschaut wird."
         },
         {
-          "title": "Self-Organisation",
+          "title": "Selbstorganisation",
           "description": "Jedes Team bei Satellytes ist für seine eigenen Aufgaben verantwortlich. In den Worten des Agilen Manifests: „Die besten Architekturen, Anforderungen und Entwürfe entstehen durch selbstorganisierte Teams.“"
         },
         {
@@ -105,7 +103,7 @@
         },
         {
           "title": "Feedback",
-          "description": "Zusammenarbeit ist bei uns nicht nur ein Wort: Code-Review, Inline-Kommentare, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback usw."
+          "description": "Feedback ist unser wichtigstes Instrument. Code Reviews, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback und mehr geben jedem die Möglichkeit sich stetig zu verbessern."
         },
         {
           "title": "Open Work",
@@ -173,7 +171,7 @@
     "leadbox": {
       "title": "Deine Stelle nicht dabei?",
       "subtitle": "Initiativbewerbung",
-      "text": "Georgios Kaleadis, HR Manager",
+      "text": "Georgios Kaleadis, CTO",
       "mail": "career@satellytes.com"
     }
   },

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -34,6 +34,98 @@
     "other": "other",
     "info-text": "Please upload relevant files e.g. CV, cover letter or references. You can upload 3 pdf-documents with a maximal size of 20 MB each.",
     "privacy-policy": "<0>I hereby confirm that i have taken note of the <1>privacy policy</1>.  <4>*</4></0>",
+    "introduction": {
+      "headline": "Arbeite mit uns",
+      "kicker": "Karriere bei Satellytes",
+      "paragraphs": [
+        "Satellytes – das sind aktuell 14 ausschließlich leidenschaftliche Entwickler:innen und Designer:innen. Wir haben großen Spaß an Technologie und freuen uns auf neue Herausforderungen. Dabei fokussieren wir uns auf langfristige Engagements im Konzerngeschäft.",
+        "Neuen Aufgaben begegnen wir immer mit angemessenem Respekt. Wir streben stets hochwertige und zeitgemäße Lösungen an – die Wahl der Technologie ist für uns dabei sekundär.",
+        "Unser Büro befindet sich in einem wunderschönen Altbau im Herzen Münchens, in der Sendlinger Straße, unweit der gleichnamigen U-Bahn-Station. In Laufweite gibt es nicht nur dutzende Läden, Cafés, Restaurants und den bekannten Viktualienmarkt, sondern auch diverse kleinere und größere Parks. Sogar die Isar ist in der Mittagspause fußläufig oder mit der U-Bahn in nur 3 Minuten zu erreichen."
+      ]
+    },
+    "application-process": {
+      "headline": "Bewerbungsprozess",
+      "paragraph": "Sich auf einen Job zu bewerben kann oft frustrierend sein. Unser Team hat sich deshalb etwas überlegt was Sinn macht. Schau dir hier unsere vier Schritte deiner Bewerbung an.",
+      "accordion": [
+        {
+          "title": "1. Bewerb dich",
+          "paragraph": "Alles beginnt mit deiner Bewerbung. Schicke uns deinen Lebenslauf und ein kleines Anschreiben, wieso du dich gerade bei uns bewirbst. In deiner Bewerbung achten wir nicht auf Schulnoten sondern suchen nach deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab Account. Hast du einen Blog? Dann verweise gerne darauf."
+        },
+        {
+          "title": "2. Kennenlernen",
+          "paragraph": "Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen Kollegen mit dir sprechen und wir reden darüber wie du zum Programmieren gekommen bist und was dich antreibt. Danach werden wir dich besser kennen und du kennst die ersten Gesichter hinter Satellytes."
+        },
+        {
+          "title": "3. Technisches Interview",
+          "paragraph": "Wir machen weder Whiteboard Interviews, noch schicken wir die irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code Review durchführen, die wir dann zusammen im Interview durchsprechen. Hier werden sich ganz automatische spannende Gespräch ergeben. Wir werden Probleme im Code besprechen und das ein oder andere Fachwissen über relevante Technologien ansprechen. Neben der ganzen Technik haben wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um sicherzustellen dass du dich bei uns wohl fühlst."
+        },
+        {
+          "title": "4. Entscheidung",
+          "paragraph": "Du hast gezeigt was du kannst und wie du arbeitest. Wir haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt lassen wir es dich wissen. Passt etwas nicht, dann lassen wir das dich ebenfalls wissen."
+        }
+      ]
+    },
+    "openings": {
+      "headline": "Unsere offenen Stellen"
+    },
+    "culture": {
+      "headline": "Spass an der Arbeit",
+      "kicker": "Team",
+      "paragraph": "Wir möchten die Voraussetzung schaffen, damit sich jeder persönlich wie beruflich weiterentwickeln kann.",
+      "teaser": [
+        {
+          "title": "Cross-Functional",
+          "description": "Teams aus Designern, Produktmanagern, Entwicklern, Supportmitarbeitern, Marketingspezialisten usw. bringen die richtige Mischung aus Know-how und Erfahrung mit und sorgen dafür, dass auch mal über den Tellerrand geschaut wird."
+        },
+        {
+          "title": "Self-Organisation",
+          "description": "Jedes Team bei Satellytes ist für seine eigenen Aufgaben verantwortlich. In den Worten des Agilen Manifests: „Die besten Architekturen, Anforderungen und Entwürfe entstehen durch selbstorganisierte Teams.“"
+        },
+        {
+          "title": "Agile",
+          "description": "Schnelles Feedback, kurze Entscheidungswege und Offenheit für Veränderung sind uns wichtig – egal, ob man es Scrum, Kanban oder XP nennt."
+        },
+        {
+          "title": "Erfolgreich scheitern",
+          "description": "Wenn wir etwas Neues ausprobieren, riskieren wir immer auch einen Misserfolg. Macht nichts – aus Fehlern lernen, Erkenntnisse mit anderen teilen und im nächsten Projekt in Erfolge ummünzen."
+        },
+        {
+          "title": "Feedback",
+          "description": "Zusammenarbeit ist bei uns nicht nur ein Wort: Code-Review, Inline-Kommentare, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback usw."
+        },
+        {
+          "title": "Open Work",
+          "description": "Offen sein, zuhören, andere Meinungen respektieren und gemeinsam die besten Lösungen finden."
+        }
+      ]
+    },
+    "perk": {
+      "headline": "Perks & Benefits",
+      "kicker": "Arbeiten",
+      "paragraph": "Neben einem großartigen Team, interessanten Aufgaben und einer modernen Arbeitsumgebung bieten wir noch weitere Extras.",
+      "teaser": [
+        {
+          "title": "Zeit für Experimente",
+          "description": "Bei uns bekommst du Raum, um neue Technologien auszuprobieren oder mit Kollegen kleine Experimente durchzuführen"
+        },
+        {
+          "title": "Lebenslanges Lernen",
+          "description": "Du wirst bei uns jeden Tag etwas lernen, egal ob du dich als Anfänger oder Profi siehst. Sollte dir selbst mal die Muse fehlen, dann wird ein Kollege dich sicherlich kurz später zu inspirieren wissen. Und wenn du mal ein Buch brauchst: Jedes Buch geht auf uns."
+        },
+        {
+          "title": "Lieblingsausrüstung",
+          "description": "Ob MacBook oder Linux Laptop? Ob Maus oder Trackpad oder VSCode oder IntelliJ. Du hast bei uns die Wahl."
+        },
+        {
+          "title": "Arbeiten wo du willst",
+          "description": "Arbeitszeit und Arbeitsort kannst du nach Absprache mit dem Team & Kunden flexibel wählen."
+        },
+        {
+          "title": "Konferenzen",
+          "description": "Wir lieben Tech-Konferenzen und sind schon oft Besucher und manchmal sogar Speaker gewesen. Wir zahlen dir Ticket, Kost und Logis. Willst du Speaker werden? Wir unterstützen dich dabei."
+        }
+      ]
+    },
     "error": {
       "approval": "Your approval is missing",
       "first-name": "Your first name is missing",

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -35,94 +35,92 @@
     "info-text": "Please upload relevant files e.g. CV, cover letter or references. You can upload 3 pdf-documents with a maximal size of 20 MB each.",
     "privacy-policy": "<0>I hereby confirm that i have taken note of the <1>privacy policy</1>.  <4>*</4></0>",
     "introduction": {
-      "headline": "Arbeite mit uns",
-      "kicker": "Karriere bei Satellytes",
+      "headline": "Work with us",
+      "kicker": "Career at Satellytes",
       "paragraphs": [
-        "Satellytes – das sind aktuell 14 ausschließlich leidenschaftliche Entwickler:innen und Designer:innen. Wir haben großen Spaß an Technologie und freuen uns auf neue Herausforderungen. Dabei fokussieren wir uns auf langfristige Engagements im Konzerngeschäft.",
-        "Neuen Aufgaben begegnen wir immer mit angemessenem Respekt. Wir streben stets hochwertige und zeitgemäße Lösungen an – die Wahl der Technologie ist für uns dabei sekundär.",
-        "Unser Büro befindet sich in einem wunderschönen Altbau im Herzen Münchens, in der Sendlinger Straße, unweit der gleichnamigen U-Bahn-Station. In Laufweite gibt es nicht nur dutzende Läden, Cafés, Restaurants und den bekannten Viktualienmarkt, sondern auch diverse kleinere und größere Parks. Sogar die Isar ist in der Mittagspause fußläufig oder mit der U-Bahn in nur 3 Minuten zu erreichen."
+        "We are Satellytes, a team of highly experienced developers and some designers. We bring sustainable, accessible, reliable and modern web solutions to large companies. If you are interested in joining us, check out our open positions right now."
       ]
     },
     "application-process": {
-      "headline": "Bewerbungsprozess",
-      "paragraph": "Sich auf einen Job zu bewerben kann oft frustrierend sein. Unser Team hat sich deshalb etwas überlegt was Sinn macht. Schau dir hier unsere vier Schritte deiner Bewerbung an.",
+      "headline": "Application process",
+      "paragraph": "Applying for a job can often be frustrating. That's why our team has come up with something that makes sense. Check out our four steps of your application here.",
       "accordion": [
         {
-          "title": "1. Bewerb dich",
-          "paragraph": "Alles beginnt mit deiner Bewerbung. Schicke uns deinen Lebenslauf und ein kleines Anschreiben, wieso du dich gerade bei uns bewirbst. In deiner Bewerbung achten wir nicht auf Schulnoten sondern suchen nach deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab Account. Hast du einen Blog? Dann verweise gerne darauf."
+          "title": "1. Apply",
+          "paragraph": "Everything starts with your application. Send us your CV and a short cover letter explaining why you are applying to us. In your application, we don't look for school grades, we look for your passion for coding. Show us your GitHub or GitLab account. Do you have a blog? Then feel free to link to it."
         },
         {
-          "title": "2. Kennenlernen",
-          "paragraph": "Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen Kollegen mit dir sprechen und wir reden darüber wie du zum Programmieren gekommen bist und was dich antreibt. Danach werden wir dich besser kennen und du kennst die ersten Gesichter hinter Satellytes."
+          "title": "2. Say Hello",
+          "paragraph": "If we find your application convincing, we will invite you to a first interview. One or two of your future colleagues will talk to you about how you got into programming and what drives you. After that, we will know you better and you will know the first faces behind Satellytes."
         },
         {
-          "title": "3. Technisches Interview",
-          "paragraph": "Wir machen weder Whiteboard Interviews, noch schicken wir die irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code Review durchführen, die wir dann zusammen im Interview durchsprechen. Hier werden sich ganz automatische spannende Gespräch ergeben. Wir werden Probleme im Code besprechen und das ein oder andere Fachwissen über relevante Technologien ansprechen. Neben der ganzen Technik haben wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um sicherzustellen dass du dich bei uns wohl fühlst."
+          "title": "3. Technical Interview",
+          "paragraph": "We don't do whiteboard interviews, nor do we send any programming tasks. Instead, you'll do a code review in advance, which we'll then talk through together in the interview. We'll discuss issues in the code and touch on a bit of expertise about relevant technologies. Besides all the technical stuff, we'll also have time to talk a bit about our culture at Satellytes to make sure you feel comfortable working with us."
         },
         {
-          "title": "4. Entscheidung",
-          "paragraph": "Du hast gezeigt was du kannst und wie du arbeitest. Wir haben gezeigt was uns antreibt und wie wir arbeiten. Wenn alles passt lassen wir es dich wissen. Passt etwas nicht, dann lassen wir das dich ebenfalls wissen."
+          "title": "4. Decision",
+          "paragraph": "You have shown what you can do and how you're working. We have shown what drives us and how we work. If everything fits, we let you know. If something doesn't fit, we'll let you know that too."
         }
       ]
     },
     "openings": {
-      "headline": "Unsere offenen Stellen"
+      "headline": "Open Positions"
     },
     "culture": {
-      "headline": "Spass an der Arbeit",
+      "headline": "Enjoying the work",
       "kicker": "Team",
-      "paragraph": "Wir möchten die Voraussetzung schaffen, damit sich jeder persönlich wie beruflich weiterentwickeln kann.",
+      "paragraph": "We want to create the conditions for everyone to develop personally and professionally.",
       "teaser": [
         {
           "title": "Cross-Functional",
-          "description": "Teams aus Designern, Produktmanagern, Entwicklern, Supportmitarbeitern, Marketingspezialisten usw. bringen die richtige Mischung aus Know-how und Erfahrung mit und sorgen dafür, dass auch mal über den Tellerrand geschaut wird."
+          "description": "Mixed teams of designers, product managers, developers, support staff, marketing specialists and more bring the right combination of know-how and experience to ensure that people think outside the box."
         },
         {
-          "title": "Self-Organisation",
-          "description": "Jedes Team bei Satellytes ist für seine eigenen Aufgaben verantwortlich. In den Worten des Agilen Manifests: „Die besten Architekturen, Anforderungen und Entwürfe entstehen durch selbstorganisierte Teams.“"
+          "title": "Self-organisation",
+          "description": "Each team at Satellytes is responsible for its own tasks. In the words of the Agile Manifesto: \"The best architectures, requirements and designs are created by self-organized teams\""
         },
         {
           "title": "Agile",
-          "description": "Schnelles Feedback, kurze Entscheidungswege und Offenheit für Veränderung sind uns wichtig – egal, ob man es Scrum, Kanban oder XP nennt."
+          "description": "Fast feedback, short decision-making processes and open mindedness are important to us - whether you call it Scrum, Kanban or XP."
         },
         {
-          "title": "Erfolgreich scheitern",
-          "description": "Wenn wir etwas Neues ausprobieren, riskieren wir immer auch einen Misserfolg. Macht nichts – aus Fehlern lernen, Erkenntnisse mit anderen teilen und im nächsten Projekt in Erfolge ummünzen."
+          "title": "Fail fast",
+          "description": "When we try something new, we always risk failure. That's the ideal way to learn from mistakes, share insights with others and turn them into successes in the next situation."
         },
         {
           "title": "Feedback",
-          "description": "Zusammenarbeit ist bei uns nicht nur ein Wort: Code-Review, Inline-Kommentare, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback usw."
+          "description": "Feedback is our most important tool. Code reviews, pair programming, daily stand-up meetings, 360-degree feedback and more give everyone the opportunity to constantly improve."
         },
         {
           "title": "Open Work",
-          "description": "Offen sein, zuhören, andere Meinungen respektieren und gemeinsam die besten Lösungen finden."
+          "description": "Being open, listening, respecting other opinions and finding the best solutions together."
         }
       ]
     },
     "perk": {
       "headline": "Perks & Benefits",
-      "kicker": "Arbeiten",
-      "paragraph": "Neben einem großartigen Team, interessanten Aufgaben und einer modernen Arbeitsumgebung bieten wir noch weitere Extras.",
+      "kicker": "Work",
+      "paragraph": "In addition to a great team, interesting tasks and a modern working environment, we also offer a few extras.",
       "teaser": [
         {
-          "title": "Zeit für Experimente",
-          "description": "Bei uns bekommst du Raum, um neue Technologien auszuprobieren oder mit Kollegen kleine Experimente durchzuführen"
+          "title": "Time for experiments",
+          "description": "You'll get time & space to try out new technologies or conduct small experiments with colleagues"
         },
         {
-          "title": "Lebenslanges Lernen",
-          "description": "Du wirst bei uns jeden Tag etwas lernen, egal ob du dich als Anfänger oder Profi siehst. Sollte dir selbst mal die Muse fehlen, dann wird ein Kollege dich sicherlich kurz später zu inspirieren wissen. Und wenn du mal ein Buch brauchst: Jedes Buch geht auf uns."
+          "title": "Always learning",
+          "description": "You will learn something with us every day, whether you consider yourself a beginner or a professional. If you're lacking the muse yourself, then a colleague will surely know how to inspire you shortly afterwards. If you ever need a book: every book is on us."
         },
         {
-          "title": "Lieblingsausrüstung",
-          "description": "Ob MacBook oder Linux Laptop? Ob Maus oder Trackpad oder VSCode oder IntelliJ. Du hast bei uns die Wahl."
+          "title": "Favorite gear",
+          "description": "MacBook vs. Linux laptop, mouse vs. trackpad or VSCode vs. IntelliJ. You have the choice with us."
         },
         {
-          "title": "Arbeiten wo du willst",
-          "description": "Arbeitszeit und Arbeitsort kannst du nach Absprache mit dem Team & Kunden flexibel wählen."
+          "title": "Work from anywhere",
+          "description": "You can flexibly choose your working hours and place of work after consultation with the team & customers."
         },
         {
-          "title": "Konferenzen",
-          "description": "Wir lieben Tech-Konferenzen und sind schon oft Besucher und manchmal sogar Speaker gewesen. Wir zahlen dir Ticket, Kost und Logis. Willst du Speaker werden? Wir unterstützen dich dabei."
+          "title": "Conferences",
+          "description": "We love tech conferences and have often been visitors and sometimes even speakers. We'll pay for your ticket, room and board. Want to become a speaker? We support you."
         }
       ]
     },
@@ -159,7 +157,7 @@
     "leadbox": {
       "title": "Your job not included?",
       "subtitle": "Unsolicited Application",
-      "text": "Georgios Kaleadis, HR Manager",
+      "text": "Georgios Kaleadis, CTO",
       "mail": "career@satellytes.com"
     }
   },

--- a/src/page-building/career/application-process.tsx
+++ b/src/page-building/career/application-process.tsx
@@ -5,62 +5,47 @@ import {
 } from '../../components/accordion/accordion';
 import styled from 'styled-components';
 import { SectionHeader } from '../../new-components/section-header/section-header';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 const Spacer = styled.div`
   margin-bottom: 48px;
 `;
 
 export const ApplicationProcess = () => {
+  const { t } = useTranslation();
   return (
     <>
-      <SectionHeader headline="Bewerbungsprozess">
-        Sich auf einen Job zu bewerben kann oft frustrierend sein. Unser Team
-        hat sich deshalb etwas überlegt was Sinn macht. Schau dir hier unsere
-        vier Schritte deiner Bewerbung an.
+      <SectionHeader headline={t('career.application-process.headline')}>
+        {t('career.application-process.paragraph')}
       </SectionHeader>
 
       <Spacer />
 
       <Accordion defaultIndex={0}>
         <AccordionSection
-          title="1. Bewerb dich"
+          title={t('career.application-process.accordion.0.title')}
           illustration={'scientistB_007'}
         >
-          Alles beginnt mit deiner Bewerbung. Schicke uns deinen Lebenslauf und
-          ein kleines Anschreiben, wieso du dich gerade bei uns bewirbst. In
-          deiner Bewerbung achten wir nicht auf Schulnoten sondern suchen nach
-          deiner Leidenschaft fürs Coden. Zeig uns deinen GitHub oder GitLab
-          Account. Hast du einen Blog? Dann verweise gerne darauf.
+          {t('career.application-process.accordion.0.paragraph')}
         </AccordionSection>
 
         <AccordionSection
-          title="2. Kennenlernen"
+          title={t('career.application-process.accordion.1.title')}
           illustration={'astronaut_015'}
         >
-          Wenn wir deine Bewerbung überzeugend finden, laden wir dich zu einem
-          ersten Gespräch ein. Hier werden ein oder zwei deiner zukünftigen
-          Kollegen mit dir sprechen und wir reden darüber wie du zum
-          Programmieren gekommen bist und was dich antreibt. Danach werden wir
-          dich besser kennen und du kennst die ersten Gesichter hinter
-          Satellytes.
+          {t('career.application-process.accordion.1.paragraph')}
         </AccordionSection>
 
-        <AccordionSection title="3. Technisches Interview">
-          Wir machen weder Whiteboard Interviews, noch schicken wir die
-          irgendwelche Programmieraufgaben. Stattdessen wirst du vorab eine Code
-          Review durchführen, die wir dann zusammen im Interview durchsprechen.
-          Hier werden sich ganz automatische spannende Gespräch ergeben. Wir
-          werden Probleme im Code besprechen und das ein oder andere Fachwissen
-          über relevante Technologien ansprechen. Neben der ganzen Technik haben
-          wir auch Zeit etwas über unsere Kultur bei Satellytes zu sprechen, um
-          sicherzustellen dass du dich bei uns wohl fühlst.
+        <AccordionSection
+          title={t('career.application-process.accordion.2.title')}
+        >
+          {t('career.application-process.accordion.2.paragraph')}
         </AccordionSection>
 
-        <AccordionSection title="4. Entscheidung">
-          Du hast gezeigt was du kannst und wie du arbeitest. Wir haben gezeigt
-          was uns antreibt und wie wir arbeiten. Wenn alles passt lassen wir es
-          dich wissen. Passt etwas nicht, dann lassen wir das dich ebenfalls
-          wissen.
+        <AccordionSection
+          title={t('career.application-process.accordion.3.title')}
+        >
+          {t('career.application-process.accordion.3.paragraph')}
         </AccordionSection>
       </Accordion>
     </>

--- a/src/page-building/career/career-page.tsx
+++ b/src/page-building/career/career-page.tsx
@@ -50,17 +50,15 @@ export const CareerPage = ({ positions }: CareerPageProps) => {
           headline={t('career.introduction.headline')}
         >
           <Paragraph>{t('career.introduction.paragraphs.0')}</Paragraph>
-          <Paragraph>{t('career.introduction.paragraphs.1')}</Paragraph>
-          <Paragraph>{t('career.introduction.paragraphs.2')}</Paragraph>
         </SectionHeader>
       </ContentBlockContainer>
 
       <ContentBlockContainer>
-        <ApplicationProcess />
+        <Openings jobs={positions} />
       </ContentBlockContainer>
 
       <ContentBlockContainer>
-        <Openings jobs={positions} />
+        <ApplicationProcess />
       </ContentBlockContainer>
 
       <ContentBlockContainer>

--- a/src/page-building/career/career-page.tsx
+++ b/src/page-building/career/career-page.tsx
@@ -46,29 +46,12 @@ export const CareerPage = ({ positions }: CareerPageProps) => {
     >
       <ContentBlockContainer>
         <SectionHeader
-          kicker="Karriere bei Satellytes"
-          headline="Arbeite mit uns"
+          kicker={t('career.introduction.kicker')}
+          headline={t('career.introduction.headline')}
         >
-          <Paragraph>
-            Satellytes – das sind aktuell 14 ausschließlich leidenschaftliche
-            Entwickler:innen und Designer:innen. Wir haben großen Spaß an
-            Technologie und freuen uns auf neue Herausforderungen. Dabei
-            fokussieren wir uns auf langfristige Engagements im Konzerngeschäft.
-          </Paragraph>
-          <Paragraph>
-            Neuen Aufgaben begegnen wir immer mit angemessenem Respekt. Wir
-            streben stets hochwertige und zeitgemäße Lösungen an – die Wahl der
-            Technologie ist für uns dabei sekundär.
-          </Paragraph>
-          <Paragraph>
-            Unser Büro befindet sich in einem wunderschönen Altbau im Herzen
-            Münchens, in der Sendlinger Straße, unweit der gleichnamigen
-            U-Bahn-Station. In Laufweite gibt es nicht nur dutzende Läden,
-            Cafés, Restaurants und den bekannten Viktualienmarkt, sondern auch
-            diverse kleinere und größere Parks. Sogar die Isar ist in der
-            Mittagspause fußläufig oder mit der U-Bahn in nur 3 Minuten zu
-            erreichen.
-          </Paragraph>
+          <Paragraph>{t('career.introduction.paragraphs.0')}</Paragraph>
+          <Paragraph>{t('career.introduction.paragraphs.1')}</Paragraph>
+          <Paragraph>{t('career.introduction.paragraphs.2')}</Paragraph>
         </SectionHeader>
       </ContentBlockContainer>
 
@@ -78,10 +61,6 @@ export const CareerPage = ({ positions }: CareerPageProps) => {
 
       <ContentBlockContainer>
         <Openings jobs={positions} />
-      </ContentBlockContainer>
-
-      <ContentBlockContainer>
-        <Culture />
       </ContentBlockContainer>
 
       <ContentBlockContainer>

--- a/src/page-building/career/culture.tsx
+++ b/src/page-building/career/culture.tsx
@@ -7,6 +7,12 @@ import { IllustrationType } from '../../components/illustration/illustration-set
 import { SectionHeader } from '../../new-components/section-header/section-header';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 
+interface CultureAspect {
+  illustration: IllustrationType;
+  title: string;
+  description: string;
+}
+
 const TeaserGrid = styled.div`
   display: grid;
   gap: 24px;
@@ -19,13 +25,41 @@ const TeaserGrid = styled.div`
   }
 `;
 
-const ILLUSTRATIONS: IllustrationType[] = [
-  'radar_030',
-  'rocket_011',
-  'sputnik_045',
-  'planets_005',
-  'report_031',
-  'book_038',
+const ASPECTS = (t): CultureAspect[] => [
+  {
+    title: t('career.culture.teaser.0.title'),
+    description: t('career.culture.teaser.0.description'),
+    illustration: 'radar_030',
+  },
+
+  {
+    title: t('career.culture.teaser.1.title'),
+    description: t('career.culture.teaser.1.description'),
+    illustration: 'rocket_011',
+  },
+
+  {
+    title: t('career.culture.teaser.2.title'),
+    description: t('career.culture.teaser.2.description'),
+    illustration: 'sputnik_045',
+  },
+
+  {
+    title: t('career.culture.teaser.3.title'),
+    description: t('career.culture.teaser.3.description'),
+    illustration: 'planets_005',
+  },
+
+  {
+    title: t('career.culture.teaser.4.title'),
+    description: t('career.culture.teaser.4.description'),
+    illustration: 'report_031',
+  },
+  {
+    title: t('career.culture.teaser.5.title'),
+    description: t('career.culture.teaser.5.description'),
+    illustration: 'book_038',
+  },
 ];
 
 const CultureTeaserGrid = styled(TeaserGrid)`
@@ -44,13 +78,13 @@ export const Culture = () => {
       </SectionHeader>
 
       <CultureTeaserGrid>
-        {ILLUSTRATIONS.map((illustration, index) => (
+        {ASPECTS(t).map((item, index) => (
           <Teaser
-            title={t(`career.culture.teaser.${index}.title`)}
+            title={item.title}
             key={index}
-            cover={<Illustration show={illustration} />}
+            cover={<Illustration show={item.illustration} />}
           >
-            {t(`career.culture.teaser.${index}.description`)}
+            {item.description}
           </Teaser>
         ))}
       </CultureTeaserGrid>

--- a/src/page-building/career/culture.tsx
+++ b/src/page-building/career/culture.tsx
@@ -5,12 +5,7 @@ import { Teaser } from '../../components/teasers/teaser';
 import { Illustration } from '../../components/illustration/illustration';
 import { IllustrationType } from '../../components/illustration/illustration-set';
 import { SectionHeader } from '../../new-components/section-header/section-header';
-
-interface CultureAspect {
-  illustration: IllustrationType;
-  title: string;
-  description: string;
-}
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 const TeaserGrid = styled.div`
   display: grid;
@@ -24,47 +19,13 @@ const TeaserGrid = styled.div`
   }
 `;
 
-const ASPECTS: CultureAspect[] = [
-  {
-    title: 'Cross-Functional',
-    description:
-      'Teams aus Designern, Produktmanagern, Entwicklern, Supportmitarbeitern, Marketingspezialisten usw. bringen die richtige Mischung aus Know-how und Erfahrung mit und sorgen dafür, dass auch mal über den Tellerrand geschaut wird.',
-    illustration: 'radar_030',
-  },
-
-  {
-    title: 'Self-Organisation',
-    description:
-      'Jedes Team bei Satellytes ist für seine eigenen Aufgaben verantwortlich. In den Worten des Agilen Manifests: „Die besten Architekturen, Anforderungen und Entwürfe entstehen durch selbstorganisierte Teams.“',
-    illustration: 'rocket_011',
-  },
-
-  {
-    title: 'Agile',
-    description:
-      'Schnelles Feedback, kurze Entscheidungswege und Offenheit für Veränderung sind uns wichtig – egal, ob man es Scrum, Kanban oder XP nennt.',
-    illustration: 'sputnik_045',
-  },
-
-  {
-    title: 'Erfolgreich scheitern',
-    description:
-      'Wenn wir etwas Neues ausprobieren, riskieren wir immer auch einen Misserfolg. Macht nichts – aus Fehlern lernen, Erkenntnisse mit anderen teilen und im nächsten Projekt in Erfolge ummünzen.',
-    illustration: 'planets_005',
-  },
-
-  {
-    title: 'Feedback',
-    description:
-      'Zusammenarbeit ist bei uns nicht nur ein Wort: Code-Review, Inline-Kommentare, Pair Programming, tägliche Stand-up-Meetings, 360-Grad-Feedback usw.',
-    illustration: 'report_031',
-  },
-  {
-    title: 'Open Work',
-    description:
-      'Offen sein, zuhören, andere Meinungen respektieren und gemeinsam die besten Lösungen finden.',
-    illustration: 'book_038',
-  },
+const ILLUSTRATIONS: IllustrationType[] = [
+  'radar_030',
+  'rocket_011',
+  'sputnik_045',
+  'planets_005',
+  'report_031',
+  'book_038',
 ];
 
 const CultureTeaserGrid = styled(TeaserGrid)`
@@ -72,21 +33,24 @@ const CultureTeaserGrid = styled(TeaserGrid)`
 `;
 
 export const Culture = () => {
+  const { t } = useTranslation();
   return (
     <>
-      <SectionHeader kicker="Team" headline="Spass an der Arbeit">
-        Wir möchten die Voraussetzung schaffen, damit sich jeder persönlich wie
-        beruflich weiterentwickeln kann.
+      <SectionHeader
+        kicker={t('career.culture.kicker')}
+        headline={t('career.culture.headline')}
+      >
+        {t('career.culture.paragraph')}
       </SectionHeader>
 
       <CultureTeaserGrid>
-        {ASPECTS.map((item, index) => (
+        {ILLUSTRATIONS.map((illustration, index) => (
           <Teaser
-            title={item.title}
+            title={t(`career.culture.teaser.${index}.title`)}
             key={index}
-            cover={<Illustration show={item.illustration} />}
+            cover={<Illustration show={illustration} />}
           >
-            {item.description}
+            {t(`career.culture.teaser.${index}.description`)}
           </Teaser>
         ))}
       </CultureTeaserGrid>

--- a/src/page-building/career/openings.tsx
+++ b/src/page-building/career/openings.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { up } from '../../components/style-utils/breakpoint';
 import { TextStyles } from '../../components/typography/typography-v2';
 import { SyPersonioJob } from '../../types';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 const TeaserGrid = styled.div`
   display: grid;
@@ -28,9 +29,10 @@ interface OpeningsProps {
 }
 
 export const Openings = (props: OpeningsProps) => {
+  const { t } = useTranslation();
   return (
     <div>
-      <SectionHeadline>Unsere offenen Stellen</SectionHeadline>
+      <SectionHeadline>{t('career.openings.headline')}</SectionHeadline>
       <TeaserGrid>
         {props.jobs.map((item) => (
           <Teaser title={item.name} linkTo={item.fields?.path} key={item.id}>

--- a/src/page-building/career/perks.tsx
+++ b/src/page-building/career/perks.tsx
@@ -5,10 +5,7 @@ import { Illustration } from '../../components/illustration/illustration';
 import { up } from '../../components/style-utils/breakpoint';
 import { IllustrationType } from '../../components/illustration/illustration-set';
 import { SectionHeader } from '../../new-components/section-header/section-header';
-
-interface Perk {
-  illustration: IllustrationType;
-}
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 const TeaserGrid = styled.div`
   display: grid;
@@ -22,47 +19,12 @@ const TeaserGrid = styled.div`
   }
 `;
 
-interface Perk {
-  illustration: IllustrationType;
-  title: string;
-  description: string;
-}
-
-const PERKS: Perk[] = [
-  {
-    title: 'Zeit für Experimente',
-    description:
-      'Bei uns bekommst du Raum, um neue Technologien auszuprobieren oder mit Kollegen kleine Experimente durchzuführen',
-    illustration: 'scientistA_006',
-  },
-
-  {
-    title: 'Lebenslanges Lernen',
-    description:
-      'Du wirst bei uns jeden Tag etwas lernen, egal ob du dich als Anfänger oder Profi siehst. Sollte dir selbst mal die Muse fehlen, dann wird ein Kollege dich sicherlich kurz später zu inspirieren wissen. Und wenn du mal ein Buch brauchst: Jedes Buch geht auf uns.',
-    illustration: 'universe_003',
-  },
-
-  {
-    title: 'Lieblingsausrüstung',
-    description:
-      'Ob MacBook oder Linux Laptop? Ob Maus oder Trackpad oder VSCode oder IntelliJ. Du hast bei uns die Wahl.',
-    illustration: 'monitor_024',
-  },
-
-  {
-    title: 'Arbeiten wo du willst',
-    description:
-      'Arbeitszeit und Arbeitsort kannst du nach Absprache mit dem Team & Kunden flexibel wählen.',
-    illustration: 'galaxy_013',
-  },
-
-  {
-    title: 'Konferenzen',
-    description:
-      'Wir lieben Tech-Konferenzen und sind schon oft Besucher und manchmal sogar Speaker gewesen. Wir zahlen dir Ticket, Kost und Logis. Willst du Speaker werden? Wir unterstützen dich dabei.',
-    illustration: 'planetarium_028',
-  },
+const ILLUSTRATIONS: IllustrationType[] = [
+  'scientistA_006',
+  'universe_003',
+  'monitor_024',
+  'galaxy_013',
+  'planetarium_028',
 ];
 
 const PerksTeaserGrid = styled(TeaserGrid)`
@@ -70,21 +32,24 @@ const PerksTeaserGrid = styled(TeaserGrid)`
 `;
 
 export const Perks = () => {
+  const { t } = useTranslation();
   return (
     <>
-      <SectionHeader kicker="Arbeiten" headline=" Perks & Benefits  ">
-        Neben einem großartigen Team, interessanten Aufgaben und einer modernen
-        Arbeitsumgebung bieten wir noch weitere Extras.
+      <SectionHeader
+        kicker={t('career.perk.kicker')}
+        headline={t('career.perk.headline')}
+      >
+        {t('career.perk.paragraph')}
       </SectionHeader>
 
       <PerksTeaserGrid>
-        {PERKS.map((item, index) => (
+        {ILLUSTRATIONS.map((illustration, index) => (
           <Teaser
-            title={item.title}
+            title={t(`career.perk.teaser.${index}.title`)}
             key={index}
-            cover={<Illustration show={item.illustration} />}
+            cover={<Illustration show={illustration} />}
           >
-            {item.description}
+            {t(`career.perk.teaser.${index}.description`)}
           </Teaser>
         ))}
       </PerksTeaserGrid>

--- a/src/page-building/career/perks.tsx
+++ b/src/page-building/career/perks.tsx
@@ -7,6 +7,12 @@ import { IllustrationType } from '../../components/illustration/illustration-set
 import { SectionHeader } from '../../new-components/section-header/section-header';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 
+interface Perk {
+  illustration: IllustrationType;
+  title: string;
+  description: string;
+}
+
 const TeaserGrid = styled.div`
   display: grid;
   gap: 24px;
@@ -19,12 +25,36 @@ const TeaserGrid = styled.div`
   }
 `;
 
-const ILLUSTRATIONS: IllustrationType[] = [
-  'scientistA_006',
-  'universe_003',
-  'monitor_024',
-  'galaxy_013',
-  'planetarium_028',
+const PERKS = (t): Perk[] => [
+  {
+    title: t('career.perk.teaser.0.title'),
+    description: t('career.perk.teaser.0.description'),
+    illustration: 'scientistA_006',
+  },
+
+  {
+    title: t('career.perk.teaser.1.title'),
+    description: t('career.perk.teaser.1.description'),
+    illustration: 'universe_003',
+  },
+
+  {
+    title: t('career.perk.teaser.2.title'),
+    description: t('career.perk.teaser.2.description'),
+    illustration: 'monitor_024',
+  },
+
+  {
+    title: t('career.perk.teaser.3.title'),
+    description: t('career.perk.teaser.3.description'),
+    illustration: 'galaxy_013',
+  },
+
+  {
+    title: t('career.perk.teaser.4.title'),
+    description: t('career.perk.teaser.4.description'),
+    illustration: 'planetarium_028',
+  },
 ];
 
 const PerksTeaserGrid = styled(TeaserGrid)`
@@ -43,13 +73,13 @@ export const Perks = () => {
       </SectionHeader>
 
       <PerksTeaserGrid>
-        {ILLUSTRATIONS.map((illustration, index) => (
+        {PERKS(t).map((item, index) => (
           <Teaser
-            title={t(`career.perk.teaser.${index}.title`)}
+            title={item.title}
             key={index}
-            cover={<Illustration show={illustration} />}
+            cover={<Illustration show={item.illustration} />}
           >
-            {t(`career.perk.teaser.${index}.description`)}
+            {item.description}
           </Teaser>
         ))}
       </PerksTeaserGrid>

--- a/src/pages/career.tsx
+++ b/src/pages/career.tsx
@@ -31,8 +31,8 @@ const Career = (props: CareerProps) => {
     <>
       <SEO
         imageUrl={socialCard}
-        title={`${t('contact.title')} | Satellytes`}
-        description={t('contact.info')}
+        title={`${t('career.title')} | Satellytes`}
+        description={t('career.seo.description')}
         location={props.location}
       />
       <CareerPage positions={props.data.allSyPersonioJob.nodes} />


### PR DESCRIPTION
Preview: https://satellytescommain21751-featcareertranslationkeys.gtsb.io/career/

What's included?
- In `career-page.tsx` (and its subcomponents) the hardcoded text is moved to the `translation.json` files.
- The English `translation.json` still contains the German text