### PR TITLE
refactoring: integrate new Button component

### DIFF
--- a/src/components/content/leadbox/leadbox.tsx
+++ b/src/components/content/leadbox/leadbox.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import styled from 'styled-components';
 import { TextStyles } from '../../typography';
 import { theme } from '../../layout/theme';
-import { Link, LinkButton } from '../../legacy/links/links';
+import { Link } from '../../legacy/links/links';
 import { up } from '../../support/breakpoint';
 import {
   Illustration,
   IllustrationSize,
 } from '../../ui/illustration/illustration';
 import { IllustrationType } from '../../ui/illustration/illustration-set';
+import { Button } from '../buttons/button';
 
 export interface LeadContact {
   headline: string;
@@ -128,7 +129,7 @@ interface LeadLinkProps {
 }
 
 export const LeadLink = ({ link }: LeadLinkProps) => {
-  return <LinkButton to={link.href}>{link.title}</LinkButton>;
+  return <Button to={link.href}>{link.title}</Button>;
 };
 
 export const Leadbox = (props: LeadboxProps) => {

--- a/src/components/content/leadbox/leadbox.tsx
+++ b/src/components/content/leadbox/leadbox.tsx
@@ -9,7 +9,7 @@ import {
   IllustrationSize,
 } from '../../ui/illustration/illustration';
 import { IllustrationType } from '../../ui/illustration/illustration-set';
-import { Button } from '../buttons/button';
+import { Button } from '../../ui/buttons/button';
 
 export interface LeadContact {
   headline: string;

--- a/src/components/legacy/links/links.tsx
+++ b/src/components/legacy/links/links.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link as GatsbyLink } from 'gatsby-plugin-react-i18next';
-import { RightArrowIcon } from '../icons/form-icons/right-arrow';
 import { GatsbyLinkProps } from 'gatsby';
 
 interface LinkProps extends GatsbyLinkProps<void> {
@@ -73,45 +72,3 @@ const ExternalLink = styled.a`
   text-decoration: none;
   color: inherit;
 `;
-
-const LinkButtonContainer = styled(Link)`
-  display: inline-block;
-  font-size: 16px;
-  font-weight: bold;
-  color: #fff;
-  text-decoration: none;
-  padding: 11px 16px;
-
-  background: linear-gradient(275.41deg, #543fd7 0%, #2756fd 100%);
-  border-radius: 30px;
-
-  /**
-   * todo: needs to be replaced with an svg. this also makes vertical align 
-   * middle possible / simpler   
-   */
-  svg {
-    transition: transform 0.2s ease-in;
-    margin-left: 20px;
-  }
-  :hover {
-    svg {
-      transform: translateX(2px);
-    }
-  }
-`;
-
-export const LinkButton = (props: LinkProps): JSX.Element => {
-  const {
-    children,
-    // ref is not supported by both link components
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ref,
-    ...rest
-  } = props;
-  return (
-    <LinkButtonContainer {...rest}>
-      {children}
-      <RightArrowIcon />
-    </LinkButtonContainer>
-  );
-};

--- a/src/components/pages/landingpage/blog.tsx
+++ b/src/components/pages/landingpage/blog.tsx
@@ -6,8 +6,8 @@ import { HomePageHeaderBlock } from './support';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { useLocaleFormat } from '../../i18n-helpers';
 import { BlogPostTeaser } from '../../../types';
-import { LinkButton } from '../../legacy/links/links';
 import styled from 'styled-components';
+import { Button } from '../../new-components/buttons/button';
 
 interface BlogProps {
   posts: BlogPostTeaser[];
@@ -50,7 +50,7 @@ export const Blog = ({ posts }: BlogProps) => {
       </TeaserGrid>
 
       <Spacer />
-      <LinkButton to={'/blog'}>Alle Artikel</LinkButton>
+      <Button to={'/blog'}>Alle Artikel</Button>
     </>
   );
 };

--- a/src/components/pages/landingpage/blog.tsx
+++ b/src/components/pages/landingpage/blog.tsx
@@ -7,7 +7,7 @@ import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { useLocaleFormat } from '../../i18n-helpers';
 import { BlogPostTeaser } from '../../../types';
 import styled from 'styled-components';
-import { Button } from '../../new-components/buttons/button';
+import { Button } from '../../ui/buttons/button';
 
 interface BlogProps {
   posts: BlogPostTeaser[];

--- a/src/components/pages/landingpage/career.tsx
+++ b/src/components/pages/landingpage/career.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { HomePageHeaderBlock } from './support';
 import { SyPersonioJob } from '../../../types';
 import styled from 'styled-components';
-import { Button } from '../../new-components/buttons/button';
+import { Button } from '../../ui/buttons/button';
 
 interface CareerProps {
   positions: SyPersonioJob[];

--- a/src/components/pages/landingpage/career.tsx
+++ b/src/components/pages/landingpage/career.tsx
@@ -4,8 +4,8 @@ import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
 import { HomePageHeaderBlock } from './support';
 import { SyPersonioJob } from '../../../types';
-import { LinkButton } from '../../legacy/links/links';
 import styled from 'styled-components';
+import { Button } from '../../new-components/buttons/button';
 
 interface CareerProps {
   positions: SyPersonioJob[];
@@ -35,7 +35,7 @@ export const Career = ({ positions }: CareerProps) => {
         ))}
       </TeaserGrid>
       <Spacer />
-      <LinkButton to={'/career'}>Alle offenen Stellen</LinkButton>
+      <Button to={'/career'}>Alle offenen Stellen</Button>
     </>
   );
 };

--- a/src/components/pages/landingpage/service.tsx
+++ b/src/components/pages/landingpage/service.tsx
@@ -3,8 +3,8 @@ import { TeaserGrid } from '../../content/teaser/teaser-grid';
 import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
 import { HomePageHeaderBlock } from './support';
-import { LinkButton } from '../../legacy/links/links';
 import styled from 'styled-components';
+import { Button } from '../../new-components/buttons/button';
 
 const Spacer = styled.div`
   height: 40px;
@@ -48,7 +48,7 @@ export const Service = () => {
       </TeaserGrid>
 
       <Spacer />
-      <LinkButton to={'/services'}>Learn more</LinkButton>
+      <Button to={'/services'}>Learn more</Button>
     </>
   );
 };

--- a/src/components/pages/landingpage/service.tsx
+++ b/src/components/pages/landingpage/service.tsx
@@ -4,7 +4,7 @@ import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
 import { HomePageHeaderBlock } from './support';
 import styled from 'styled-components';
-import { Button } from '../../new-components/buttons/button';
+import { Button } from '../../ui/buttons/button';
 
 const Spacer = styled.div`
   height: 40px;

--- a/src/components/ui/buttons/button.stories.mdx
+++ b/src/components/ui/buttons/button.stories.mdx
@@ -16,7 +16,21 @@ This is the Regular Button, which should be used in all the standard use cases. 
 <Canvas withSource="open">
   <Story name="Regular">
     <Button onClick={() => console.log('Regular Button clicked')}>
-      Alle Services
+      Submit
+    </Button>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Button}/>
+
+## Button vs. Anchors
+
+This component can be used both as a button and as an anchor. If the `to` prop is provided, the component is rendered as an anchor. Otherwise, the component is rendered as a button. Here you can read why this distinction is useful: https://bitsofco.de/anchors-vs-buttons/
+
+<Canvas withSource="open">
+  <Story name="Button as Link">
+    <Button to={'https://www.example.com/'}>
+      Link
     </Button>
   </Story>
 </Canvas>

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -3,13 +3,15 @@ import styled from 'styled-components';
 import { Icon, IconSize } from '../icon/icon';
 import { resetButton } from '../../support/css-helpers';
 import { lighten } from 'polished';
+import { Link } from '../../components/links/links';
 import { TextStyles } from '../../typography';
 
-const StyledButton = styled.button`
+const StyledButton = styled(Link)`
   ${resetButton};
-  ${TextStyles.toplineR}
 
-  line-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 0;
   color: #ffffff;
   border-radius: 30px;
   cursor: pointer;
@@ -25,29 +27,32 @@ const StyledButton = styled.button`
 `;
 
 const StyledIcon = styled(Icon)`
-  padding-right: 10px;
-  // pull the fixed size icon closer to the text
-  margin-left: -4px;
-  /**
-    This is a magic number to match the vertical middle of the button
-    with the icon which has a fixed bounding box which won't allow us to align
-    it based on the actual shape of the icon.
-   */
-  vertical-align: -18%;
+  margin-right: 10px;
 `;
 
 const ButtonText = styled.span`
+  ${TextStyles.toplineR};
+  line-height: 24px;
   padding-left: 16px;
-  padding-right: 16px;
+  padding-right: 6px;
 `;
 
-type RegularButtonProps = React.ComponentPropsWithoutRef<'button'>;
-
-export const Button = (props: RegularButtonProps) => {
-  return (
-    <StyledButton {...props}>
-      <ButtonText>{props.children}</ButtonText>
-      <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
-    </StyledButton>
-  );
+type RegularButtonProps = React.ComponentPropsWithoutRef<'button'> & {
+  to?: string;
 };
+
+export const Button = (props: RegularButtonProps) => (
+  <>
+    {props.to ? (
+      <StyledButton to={props.to}>
+        <ButtonText>{props.children}</ButtonText>
+        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
+      </StyledButton>
+    ) : (
+      <StyledButton as="button" {...props}>
+        <ButtonText>{props.children}</ButtonText>
+        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
+      </StyledButton>
+    )}
+  </>
+);

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Icon, IconSize } from '../icon/icon';
 import { resetButton } from '../../support/css-helpers';
 import { lighten } from 'polished';
-import { Link } from '../../components/links/links';
+import { Link } from '../../legacy/links/links';
 import { TextStyles } from '../../typography';
 
 const StyledButton = styled(Link)`

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -38,6 +38,9 @@ const ButtonText = styled.span`
 `;
 
 type RegularButtonProps = React.ComponentPropsWithoutRef<'button'> & {
+  /**
+   * If this prop is provided, the button will be rendered as `a`.
+   */
   to?: string;
 };
 

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -41,18 +41,21 @@ type RegularButtonProps = React.ComponentPropsWithoutRef<'button'> & {
   to?: string;
 };
 
-export const Button = (props: RegularButtonProps) => (
-  <>
-    {props.to ? (
+export const Button = (props: RegularButtonProps) => {
+  if (props.to) {
+    return (
       <StyledButton to={props.to}>
         <ButtonText>{props.children}</ButtonText>
-        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
+        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL}/>
       </StyledButton>
-    ) : (
+    )
+  } else {
+    return (
       <StyledButton as="button" {...props}>
         <ButtonText>{props.children}</ButtonText>
-        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
+        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL}/>
       </StyledButton>
-    )}
-  </>
-);
+    )
+  }
+};
+

--- a/src/components/ui/buttons/button.tsx
+++ b/src/components/ui/buttons/button.tsx
@@ -46,16 +46,15 @@ export const Button = (props: RegularButtonProps) => {
     return (
       <StyledButton to={props.to}>
         <ButtonText>{props.children}</ButtonText>
-        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL}/>
+        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
       </StyledButton>
-    )
+    );
   } else {
     return (
       <StyledButton as="button" {...props}>
         <ButtonText>{props.children}</ButtonText>
-        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL}/>
+        <StyledIcon show={'chevron_right'} size={IconSize.NORMAL} />
       </StyledButton>
-    )
+    );
   }
 };
-


### PR DESCRIPTION
Resolves Issue from https://github.com/satellytes/satellytes.com/issues/254
Storybook: https://deploy-preview-274--satellytes-website-storybook.netlify.app/
Preview URL: https://satellytescommain21751-choreintegratebutton.gtsb.io/

### What's included?
- `<LinkButton />` is removed and replaced with the general `<Button />` component
- The `<Button />` component can now also receive a `to` prop. If this prop is passed, the button will be rendered as `a`, otherwise as `button`.