### PR TITLE
fix: change services page meta title

### DIFF
--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -13,7 +13,7 @@ const ServicesPage = ({ location }: ServicesPageProps) => {
 
   return (
     <>
-      <SEO title={`${t('services.title')} | Satellytes`} location={location} />
+      <SEO title={`${t('services.hero')} | Satellytes`} location={location} />
       <Service />
     </>
   );


### PR DESCRIPTION
URL:  

The services page used the wrong page title. I changed the translation key in the component, the title is correct now: 
<img width="259" alt="Bildschirmfoto 2021-12-16 um 15 51 51" src="https://user-images.githubusercontent.com/57712895/146394120-0ccf7f28-cca2-46c4-8d4f-205641259c88.png">

