### PR TITLE
fix(office): correct office image paths

### DIFF
--- a/src/components/pages/about-us/office.tsx
+++ b/src/components/pages/about-us/office.tsx
@@ -31,7 +31,7 @@ export const Office = () => {
       <ImageContentWrapper>
         <Image description="" textAlign="right">
           <StaticImage
-            src="../../assets/images/office/sy-office-03.jpg"
+            src="../../../assets/images/office/sy-office-03.jpg"
             alt="kitchen"
             aspectRatio={564 / 295}
             width={564}
@@ -39,7 +39,7 @@ export const Office = () => {
         </Image>
         <Image description="" textAlign="left">
           <StaticImage
-            src="../../assets/images/office/sy-office-02.jpg"
+            src="../../../assets/images/office/sy-office-02.jpg"
             alt="kitchen"
             aspectRatio={564 / 295}
             width={564}
@@ -47,7 +47,7 @@ export const Office = () => {
         </Image>
         <Image description="" textAlign="right">
           <StaticImage
-            src="../../assets/images/office/sy-office-04.jpg"
+            src="../../../assets/images/office/sy-office-04.jpg"
             alt="kitchen"
             aspectRatio={564 / 295}
             width={564}


### PR DESCRIPTION
office images are currently not loading on the main build: https://satellytescommain21751.gatsbyjs.io/about-us/
because the relative paths changed while the past refactoring and the local cache swallowed the problem I guess.

---

Works now:
https://satellytescommain21751-gkfixoffice.gtsb.io/about-us/
![Screen Shot 2021-12-16 at 16 05 02](https://user-images.githubusercontent.com/1701755/146396329-11a9ce36-0286-4381-b10b-13cd0a857fe5.png)

