### PR TITLE
fix: adjust margin of blog overview page

### DIFF
--- a/src/components/pages/blog/blog-page.tsx
+++ b/src/components/pages/blog/blog-page.tsx
@@ -34,10 +34,7 @@ export const BlogPage = ({ posts }: BlogPageProps) => {
           {language != 'en' && <NotAvailableInGerman />}
         </BlogHeader>
       </ContentBlockContainer>
-
-      <ContentBlockContainer>
-        {language == 'en' && <Posts posts={posts} />}
-      </ContentBlockContainer>
+      {language == 'en' && <Posts posts={posts} />}
     </Layout>
   );
 };

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 import { graphql } from 'gatsby';
 import { FluidObject } from 'gatsby-image';
 
 import SEO from '../components/layout/seo';
-import { PageTitle, Text } from '../components/legacy/typography';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
-import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { LocalesQuery } from '../types';
 import { BlogPage } from '../components/pages/blog/blog-page';
 
@@ -39,7 +36,6 @@ interface BlogPageProps {
 }
 
 const Blog = ({ data, location }: BlogPageProps) => {
-  const { t } = useTranslation();
   const blogPosts = data.allMarkdownRemark.nodes;
 
   return (


### PR DESCRIPTION
URL: https://build-9d3a747e-4e8b-44cc-9fe3-a98538da6ecc.gtsb.io/blog/

## What's included?
- The spacing between the teaser grid and the blog description was too big (160px instead of 80px). I removed the unnecessary ContentblockContainer, which applied the margin
- I also removed some unnecessary imports in blog.tsx

## Preview
Before:
<img width="1427" alt="Bildschirmfoto 2021-12-16 um 16 41 28" src="https://user-images.githubusercontent.com/57712895/146402975-0c1347aa-c34a-4ee3-8e3a-3de1018bbe8d.png">
After:
<img width="1422" alt="Bildschirmfoto 2021-12-16 um 16 41 42" src="https://user-images.githubusercontent.com/57712895/146402987-e4315703-27b3-4184-937f-3c31c4309090.png">

