### PR TITLE
fix: missing trailing slash in created career paths

### DIFF
--- a/gatsby/create-node/create-career-page-path.js
+++ b/gatsby/create-node/create-career-page-path.js
@@ -5,10 +5,10 @@
 const createCareerPagePathField = ({ node, createNodeField }) => {
   const getPath = ({ slug, lang }) => {
     if (lang !== 'en') {
-      return `/${lang}/career/${slug}`;
+      return `/${lang}/career/${slug}/`;
     }
 
-    return `/career/${slug}`;
+    return `/career/${slug}/`;
   };
 
   const value = getPath(node);


### PR DESCRIPTION
Our page path field doesn't contain a leading zero.

This will cause the matcher from i18n not recognize the page and creates a translation page for the translated page. This will cause the page to be deleted and populated with the wrong data. Switching from EN to DE does not show the translated career page then.