### PR TITLE
refactor: make meta tags more solid

### DIFF
--- a/gatsby/create-pages/create-career-pages.js
+++ b/gatsby/create-pages/create-career-pages.js
@@ -58,8 +58,9 @@ const createCareerPages = async ({ actions, graphql }) => {
   positions.forEach((position) => {
     const complementPosition = complementFinder.get(position);
     const path = getTranslationPath(position.slug, position.lang);
+    // create an array of available languages, otherwise empty
     const overrideLanguages = [complementPosition?.lang ?? null].filter(
-      (n) => n !== null,
+      (language) => language !== null,
     );
 
     createPage({

--- a/gatsby/create-pages/create-career-pages.js
+++ b/gatsby/create-pages/create-career-pages.js
@@ -58,6 +58,9 @@ const createCareerPages = async ({ actions, graphql }) => {
   positions.forEach((position) => {
     const complementPosition = complementFinder.get(position);
     const path = getTranslationPath(position.slug, position.lang);
+    const overrideLanguages = [complementPosition?.lang ?? null].filter(
+      (n) => n !== null,
+    );
 
     createPage({
       path: path,
@@ -66,6 +69,7 @@ const createCareerPages = async ({ actions, graphql }) => {
         id: position.id, // internal object id which is unique across all jobs
         language: position.lang,
         translation: complementPosition?.slug ?? null,
+        overrideLanguages: overrideLanguages,
       },
     });
   });

--- a/src/components/content/heroes/blog-hero.tsx
+++ b/src/components/content/heroes/blog-hero.tsx
@@ -1,5 +1,5 @@
 import { GatsbyImage, getImage, IGatsbyImageData } from 'gatsby-plugin-image';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { HeroContainer, TextContainer } from './support';
 import { HeroText, HeroWithText } from './hero-text';
 import styled from 'styled-components';

--- a/src/components/content/heroes/support.tsx
+++ b/src/components/content/heroes/support.tsx
@@ -1,6 +1,5 @@
 import styled, { css } from 'styled-components';
 import { up } from '../../support/breakpoint';
-import React from 'react';
 import { rgba } from 'polished';
 
 /**

--- a/src/components/layout/seo.tsx
+++ b/src/components/layout/seo.tsx
@@ -3,31 +3,74 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useI18next } from 'gatsby-plugin-react-i18next';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { I18nNextData } from '../../types';
 
 const DEFAULT_META_IMAGE_URL_PATH = '/sy-share-image.jpg';
-const LANGUAGES = ['en', 'de'];
 
 interface SeoProps {
   title: string;
+  author?: string;
+  publishDate?: string;
   description?: string;
   imageUrl?: string;
   siteType?: string;
   noIndex?: boolean;
-  noTranslation?: boolean;
-  translatedPath?: string;
+  overrideLanguages?: string[] | null;
   location: Location;
 }
 
-const SEO: React.FC<SeoProps> = ({
+/**
+ * Help Google & friends to show the most appropriate version by language,
+ * for more information: https://developers.google.com/search/docs/advanced/crawling/localized-versions#html
+ *
+ * You can force a specific set of languages by passing in `overrideLanguages`
+ * which is currently used to determine of a translation is available for a given job position detail
+ * which we can query from personio upfront.
+ *
+ * Otherwise i18n-next just concludes that there is a translation as it creates a translated page
+ * for every english page by default.
+ *
+ * The function calculates a list of meta tags from a given set of i18n-next data
+ * that is available for every page.
+ */
+const buildAlternateMetaTags = (
+  { languages, language, path, originalPath, defaultLanguage }: I18nNextData,
+  host,
+  overrideLanguages,
+) => {
+  const otherLanguages =
+    overrideLanguages ?? languages.filter((item) => item !== language);
+
+  const getUrl = (path, language) => {
+    if (language === defaultLanguage) {
+      return `${host}${originalPath}`;
+    }
+    return `${host}/${language}${originalPath}`;
+  };
+
+  const alternateLanguages = otherLanguages.map((language) => {
+    const url = getUrl(originalPath, language);
+    return { url, language };
+  });
+
+  return alternateLanguages.map(({ url, language }) => {
+    return (
+      <link rel="alternate" href={url} hrefLang={language} key={language} />
+    );
+  });
+};
+
+const SEO = ({
   description = '',
   title,
+  author,
+  publishDate,
   imageUrl,
   siteType,
   noIndex,
-  translatedPath,
-  noTranslation,
+  overrideLanguages,
   location,
-}) => {
+}: SeoProps) => {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -42,78 +85,59 @@ const SEO: React.FC<SeoProps> = ({
     `,
   );
   const { t } = useTranslation();
+  const i18n = useI18next();
 
   const metaDescription = description || t('main.description');
   const typeOfSite = siteType || 'website';
-  const metaImageUrl =
-    imageUrl || site.siteMetadata.siteUrl + DEFAULT_META_IMAGE_URL_PATH;
-
-  const { language } = useI18next();
-
-  const currentPathname = location.pathname.replace('/de', '');
-
-  // functions returns links for each localized version of the page (en and de).
-  // This will help Google to show the most appropriate version by language,
-  // for more information: https://developers.google.com/search/docs/advanced/crawling/localized-versions#html
-  const listLocalizedVersions = (pathName) => {
-    return LANGUAGES.map((lang) => {
-      const languagePath = lang === 'en' ? '' : `/${lang}`;
-      const pathNameWithSlashes =
-        language !== lang && translatedPath
-          ? prependAndAppendTrailingSlash(translatedPath)
-          : pathName;
-      const href = `${location.origin}${languagePath}${pathNameWithSlashes}`;
-      return <link rel="alternate" href={href} hrefLang={lang} key={lang} />;
-    });
-  };
+  const defaultImageUrl =
+    site.siteMetadata.siteUrl + DEFAULT_META_IMAGE_URL_PATH;
+  const metaImageUrl = imageUrl ?? defaultImageUrl;
+  const alternateLanguagesMetaTags = buildAlternateMetaTags(
+    i18n,
+    location.origin,
+    overrideLanguages,
+  );
 
   return (
     <Helmet
       htmlAttributes={{
-        lang: language,
+        lang: i18n.language,
       }}
       title={title}
     >
-      {/* -- Primary tags -- */}
-      <meta name="title" property="name" content={title} />
+      {/* Standard Tags */}
+      <meta property="og:title" name="title" content={title} />
       <meta
-        name="description"
         property="og:description"
+        name="description"
         content={metaDescription}
       />
-      {metaImageUrl && <meta property="image" content={metaImageUrl} />}
-      <meta property="og:title" content={title} />
-      {metaImageUrl && <meta property="og:image" content={metaImageUrl} />}
+      <meta property="og:site_name" content={title} />
       <meta property="og:type" content={typeOfSite} />
+      <meta name="copyright" content="Satellytes" />
 
-      {/* -- Twitter Meta Tags -- */}
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:title" content={title} />
-      <meta name="twitter:description" content={metaDescription} />
-      <meta name="twitter:creator" content={site.siteMetadata.author} />
-      {metaImageUrl && <meta name="twitter:image" content={metaImageUrl} />}
-      {metaImageUrl && <meta property="twitter:image:alt" content={title} />}
+      {author && <meta property="article:author" content={author} />}
+      {publishDate && <meta property="og:publish_date" content={publishDate} />}
 
-      {/* -- Whatsapp --*/}
+      {/* Image */}
+      {metaImageUrl && <meta property="og:image" content={metaImageUrl} />}
       {metaImageUrl && (
         <meta property="og:image:secure_url" content={metaImageUrl} />
       )}
       {metaImageUrl && <meta property="og:image:width" content="400" />}
 
-      {/* -- Xing --*/}
-      <meta property="og:site_name" content={title} />
+      {/* Define twitters card format */}
+      <meta name="twitter:card" content="summary_large_image" />
 
+      {/*  Exclude robots if required
+      Reference: https://developers.google.com/search/docs/advanced/robots/robots_meta_tag 
+      */}
       {noIndex && <meta name="robots" content="noindex" />}
 
-      {/* -- Alternate Links --*/}
-      {!noTranslation && listLocalizedVersions(currentPathname)}
+      {/* Alternate Links */}
+      {alternateLanguagesMetaTags}
     </Helmet>
   );
-};
-
-const prependAndAppendTrailingSlash = (path) => {
-  const prependedPath = path.startsWith('/') ? path : `/${path}`;
-  return prependedPath.endsWith('/') ? prependedPath : `${prependedPath}/`;
 };
 
 export default SEO;

--- a/src/components/layout/seo.tsx
+++ b/src/components/layout/seo.tsx
@@ -34,22 +34,22 @@ interface SeoProps {
  * that is available for every page.
  */
 const buildAlternateMetaTags = (
-  { languages, language, path, originalPath, defaultLanguage }: I18nNextData,
+  { languages, language, originalPath, defaultLanguage }: I18nNextData,
   host,
   overrideLanguages,
 ) => {
   const otherLanguages =
     overrideLanguages ?? languages.filter((item) => item !== language);
 
-  const getUrl = (path, language) => {
-    if (language === defaultLanguage) {
+  const getUrl = (otherLanguage) => {
+    if (otherLanguage === defaultLanguage) {
       return `${host}${originalPath}`;
     }
-    return `${host}/${language}${originalPath}`;
+    return `${host}/${otherLanguage}${originalPath}`;
   };
 
   const alternateLanguages = otherLanguages.map((language) => {
-    const url = getUrl(originalPath, language);
+    const url = getUrl(language);
     return { url, language };
   });
 

--- a/src/components/pages/about-us/team.tsx
+++ b/src/components/pages/about-us/team.tsx
@@ -38,11 +38,10 @@ export const Team = ({ team }: TeamProps) => {
 
       <TeamLayout>
         {team.map((member) => {
+          const imageData = getImage(member.image);
           return (
             <Image description={member.name} textAlign="bottom" key={member.id}>
-              {member.image && (
-                <GatsbyImage alt="" image={getImage(member.image)!} />
-              )}
+              {imageData && <GatsbyImage alt="" image={imageData} />}
             </Image>
           );
         })}

--- a/src/components/pages/blog/posts.tsx
+++ b/src/components/pages/blog/posts.tsx
@@ -25,7 +25,7 @@ export const Posts = ({ posts }: PostsProps) => {
   return (
     <BlogTeaserGrid>
       {posts.map((item) => {
-        const image = getImage(item.frontmatter.featuredImage)!;
+        const imageData = getImage(item.frontmatter.featuredImage);
 
         return (
           <Teaser
@@ -33,7 +33,7 @@ export const Posts = ({ posts }: PostsProps) => {
             title={item.frontmatter.title}
             linkTo={item.frontmatter.path}
             dateFormatted={dateFormatter(item.frontmatter.date)}
-            image={image && <GatsbyImage alt="" image={image} />}
+            image={imageData && <GatsbyImage alt="" image={imageData} />}
           >
             {item.frontmatter.teaserText}
           </Teaser>

--- a/src/components/pages/landingpage/blog.tsx
+++ b/src/components/pages/landingpage/blog.tsx
@@ -33,7 +33,7 @@ export const Blog = ({ posts }: BlogProps) => {
 
       <TeaserGrid>
         {posts.map((item) => {
-          const image = getImage(item.frontmatter.featuredImage)!;
+          const imageData = getImage(item.frontmatter.featuredImage);
 
           return (
             <Teaser
@@ -42,7 +42,7 @@ export const Blog = ({ posts }: BlogProps) => {
               linkTo={item.frontmatter.path}
               language={'en'}
               dateFormatted={dateFormatter(item.frontmatter.date)}
-              image={image && <GatsbyImage alt="" image={image} />}
+              image={imageData && <GatsbyImage alt="" image={imageData} />}
             >
               {item.frontmatter.teaserText}
             </Teaser>

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -37,11 +37,12 @@ const BlogArticleTemplate: React.FC<BlogArticleTemplateProps> = ({
        */}
       <SEO
         title={`${markdown.frontmatter.title} | Satellytes`}
+        author={markdown.frontmatter.author}
+        publishDate={markdown.frontmatter.date}
         imageUrl={markdown.fields?.socialCard}
         siteType="article"
         description={markdown.frontmatter.seoMetaText ?? markdown.excerpt}
         location={location}
-        noTranslation={true}
       />
 
       <BlogPostPage markdown={markdown} breadcrumb={breadcrumb} />

--- a/src/templates/career-details.tsx
+++ b/src/templates/career-details.tsx
@@ -9,6 +9,7 @@ interface CareerPageProps {
   pageContext: {
     language: string;
     translation: string;
+    overrideLanguages: string[];
     i18n: {
       originalPath: string;
     };
@@ -34,8 +35,7 @@ const CareerPage: React.FC<CareerPageProps> = (props): JSX.Element => {
         description={t('career.seo.description-detail', {
           name: position.name,
         })}
-        translatedPath={pageContext.translation}
-        noTranslation={!pageContext.translation}
+        overrideLanguages={pageContext.overrideLanguages}
         location={props.location}
       />
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,3 +84,11 @@ export interface BreadcrumbEntry {
   pathname: string;
   label: string;
 }
+
+export interface I18nNextData {
+  languages: string[];
+  language: string;
+  path: string;
+  originalPath: string;
+  defaultLanguage: string;
+}


### PR DESCRIPTION
Initially I wanted to write a little blog post but then I entered the rabbit hole of meta tags and here we are 😅
This PR brings:
+ Removed duplicate meta tags. We can safely remove the twitter image tags as we correctly implement the open graph tags already
+ We had some wrong meta tags like `property="name"` which don't exist (property is almost exclusively used for open graph and there is no `name`
+ I replaced the hard to read `listLocalizedVersions` with a more readable version plus this fixes the fact, that we have never output any alternate tags for our default pages as far as I tested. The new versions fully rely on the i18n list of available languages. 
+ The i18n available languages do not work for our jobs. That's where a lot of technical debt poured into our codebase and I could not fix all of them with the change. I solely focused on the SEO component. I removed the `translatedPath` and `noTranslation` properties entirely and provide a `overrideLanguages` instead to be able to override the automatic list of languages that we want to offer as alternatives. This is currently only relevant for the career page. And that's where this property will be coming from: I set this during the page creation by determining the "other translations". Right now only the UX/UI position suffers from the fact that there is no translations but it's a valid edge case.

+ Added new meta tags for: author, publish_date and copyright and I fill author and publish date for blog posts already.

+ I fixed some random linting errors I saw in github.

## How to review
+ Check the existence of the alternate tags with the correct urls (do not rely on the language switch)
+ Check the meta tags. 
+ Ensure our sharing still works (use metatags.io & such)

## Next
Let's work on the language switch because it's a technical debt drama when I see how many things we pass through. I think we should introduce a context and rely on the same logic I created for the SEO component. 

I still have to figure out why linkedin shows the wrong image from the body of a blog post. Maybe we need an additional meta tags as they don't properly read the open graph image tags?