### PR TITLE
refactor: create share card from buffer

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,8 +8,8 @@ const {
 } = require('./gatsby/create-pages/create-career-pages');
 const { createFilePath } = require('gatsby-source-filesystem');
 
-exports.onCreateNode = (gatsbyCreateNodeArgs) => {
-  createPreviewCards(gatsbyCreateNodeArgs);
+exports.onCreateNode = async (gatsbyCreateNodeArgs) => {
+  await createPreviewCards(gatsbyCreateNodeArgs);
 
   const { node, actions, getNode } = gatsbyCreateNodeArgs;
   const { createNodeField } = actions;
@@ -25,6 +25,36 @@ exports.onCreateNode = (gatsbyCreateNodeArgs) => {
       value,
     });
   }
+};
+
+/**
+ * We should use `@link` and link the given foreign key field to the actual node.
+ * The before known foreign Key `___NODE` notation is deprecated, that's why we need the custom and explicit schema.
+ *
+ * You can't replace fields.socialCard hence the creation of the node in the parent.
+ * This is syntactic sugar and as as an alternative can use
+ * `schema.buildObjectType` and then resolve the reference manually through `context.nodeModel.getNodeById`
+ *
+ * Deprecation Note:
+ * https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v3-to-v4/#___node-convention-is-deprecated
+ *
+ * How to "schema additions"
+ * https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/creating-a-source-plugin/#create-foreign-key-relationships-between-data
+ */
+
+exports.createSchemaCustomization = ({ actions, schema }) => {
+  const { createTypes } = actions;
+
+  const typeDefs = [
+    `type MarkdownRemark implements Node { 
+      socialCardFile: File @link(from: "fields.socialCard")
+    }`,
+    `type SyPersonioJob implements Node { 
+      socialCardFile: File @link(from: "fields.socialCard")
+    }`,
+  ];
+
+  createTypes(typeDefs);
 };
 
 exports.createPages = async (createPagesArgs) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -47,10 +47,10 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
 
   const typeDefs = [
     `type MarkdownRemark implements Node { 
-      socialCardFile: File @link(from: "fields.socialCard")
+      socialCardFile: File @link(from: "fields.socialCardFileId")
     }`,
     `type SyPersonioJob implements Node { 
-      socialCardFile: File @link(from: "fields.socialCard")
+      socialCardFile: File @link(from: "fields.socialCardFileId")
     }`,
   ];
 

--- a/gatsby/create-node/create-preview-cards.js
+++ b/gatsby/create-node/create-preview-cards.js
@@ -20,7 +20,14 @@ const createPreviewCard = async (
   }
 
   const buffer = await generateCardToBuffer({ title });
-
+  /**
+   * The util function `createFileNodeFromBuffer` from the official gatsby source plugin `gatsby-source-filesystem`
+   * creates a file node from a given file buffer. The value of `parentNodeId` creates the necessary relationship
+   * between the original node and the actual file node so it's not garbage collected.
+   *
+   * The actual foreign key relationship is resolved through `createSchemaCustomization`
+   * in gatsby-node.js for all node types the `createPreviewCard` is invoked for.
+   */
   const fileNode = await createFileNodeFromBuffer({
     name: 'social-card',
     buffer,
@@ -33,7 +40,7 @@ const createPreviewCard = async (
   if (fileNode) {
     createNodeField({
       node,
-      name: `socialCard`,
+      name: `socialCardFileId`,
       value: fileNode.id,
     });
   }

--- a/gatsby/create-node/create-preview-cards.js
+++ b/gatsby/create-node/create-preview-cards.js
@@ -1,65 +1,51 @@
-const slugify = require('slugify');
-const path = require('path');
-const { siteMetadata } = require('../../gatsby-config');
 const {
-  generateCard,
+  generateCardToBuffer,
 } = require('../util/preview-card-generator/generate-card');
+
+const { createFileNodeFromBuffer } = require('gatsby-source-filesystem');
 
 /**
  * Create a preview card file and put the url to the Gatsby store to be able
  * to link it in the page header.
  */
-const createPreviewMarkdown = ({ node, _, actions }) => {
-  const { createNodeField } = actions;
-  const post = node.frontmatter;
+const createPreviewCard = async (
+  title,
+  { node, _, actions, getCache, createNodeId },
+) => {
+  const { createNode, createNodeField } = actions;
 
   // we need the title in order to generate anything
-  if (!post.title) {
+  if (!title) {
     return;
   }
 
-  // we create a file name from the path (which is the page slug and more unique) but if none is available take the title
-  const fileName = `social-card---${slugify(post.path || post.title, {
-    lower: true,
-  })}.jpg`;
-  const outputFile = path.join('public', fileName);
-  const imagePath = `/${fileName}`;
+  const buffer = await generateCardToBuffer({ title });
 
-  generateCard({ title: post.title }, outputFile).then(() => {
+  const fileNode = await createFileNodeFromBuffer({
+    name: 'social-card',
+    buffer,
+    getCache,
+    createNode,
+    createNodeId,
+    parentNodeId: node.id,
+  });
+
+  if (fileNode) {
     createNodeField({
       node,
       name: `socialCard`,
-      value: imagePath,
+      value: fileNode.id,
     });
-  });
+  }
 };
 
-const createPreviewJob = ({ node, _, actions }) => {
-  const { createNodeField } = actions;
-
-  const fileName = `social-card---career-${slugify(node.name, {
-    lower: true,
-  })}.jpg`;
-
-  const outputFile = path.join('public', fileName);
-  const imagePath = `/${fileName}`;
-
-  generateCard({ title: node.name }, outputFile).then(() => {
-    createNodeField({
-      node,
-      name: 'socialCard',
-      value: imagePath,
-    });
-  });
-};
-
-const createPreviewCards = ({ node, _, actions }) => {
+const createPreviewCards = async ({ node, ...rest }) => {
   if (node.internal.type === 'SyPersonioJob') {
-    createPreviewJob({ node, _, actions });
+    await createPreviewCard(node.name, { node, ...rest });
   }
 
   if (node.internal.type === 'MarkdownRemark') {
-    createPreviewMarkdown({ node, _, actions });
+    await createPreviewCard(node.frontmatter.title, { node, ...rest });
   }
 };
 

--- a/gatsby/util/preview-card-generator/generate-card.js
+++ b/gatsby/util/preview-card-generator/generate-card.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const { createCanvas, loadImage, registerFont } = require('canvas');
 
@@ -63,7 +62,7 @@ const wrapTextFactory = (context) => (text, x, y, maxWidth, lineHeight) => {
  * by composing a background with a title
  * and an optional author.
  */
-async function generateCard({ title, author }, file) {
+async function generateCardToBuffer({ title, author }) {
   const canvas = createCanvas(CARD_WIDTH, CARD_HEIGHT);
 
   const context = canvas.getContext('2d');
@@ -95,12 +94,9 @@ async function generateCard({ title, author }, file) {
     );
   }
 
-  const buffer = canvas.toBuffer('image/jpeg');
-  fs.writeFileSync(file, buffer);
-
-  return file;
+  return canvas.toBuffer('image/jpeg');
 }
 
 module.exports = {
-  generateCard,
+  generateCardToBuffer,
 };

--- a/src/pages/career.tsx
+++ b/src/pages/career.tsx
@@ -3,14 +3,16 @@ import SEO from '../components/layout/seo';
 import { graphql } from 'gatsby';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { CareerPage } from '../components/pages/career/career-page';
-import { LocalesQuery, SyPersonioJob } from '../types';
+import {
+  LocalesQuery,
+  PlainFixedImageSharpSource,
+  SyPersonioJob,
+} from '../types';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 
 interface CareerMarkdownQuery {
   htmlAst: string;
-  fields: {
-    socialCard: string;
-  };
+  socialCardFile: PlainFixedImageSharpSource;
 }
 
 interface CareerProps {
@@ -27,12 +29,13 @@ interface CareerProps {
 
 const Career = (props: CareerProps) => {
   const { t } = useTranslation();
-  const socialCard = props.data.markdownRemark?.fields?.socialCard;
+  const socialCardPath =
+    props.data.markdownRemark.socialCardFile.childImageSharp.fixed.src;
 
   return (
     <>
       <SEO
-        shareImagePath={socialCard}
+        shareImagePath={socialCardPath}
         title={`${t('career.title')} | Satellytes`}
         description={t('career.seo.description')}
         location={props.location}
@@ -81,8 +84,12 @@ export const CareerPageQuery = graphql`
       fileAbsolutePath: { regex: "/(pages/career)/" }
       frontmatter: { language: { eq: $language } }
     ) {
-      fields {
-        socialCard
+      socialCardFile {
+        childImageSharp {
+          fixed(width: 1440, height: 760) {
+            src
+          }
+        }
       }
     }
   }

--- a/src/templates/career-details.tsx
+++ b/src/templates/career-details.tsx
@@ -22,13 +22,13 @@ interface CareerPageProps {
 const CareerPage: React.FC<CareerPageProps> = (props): JSX.Element => {
   const { pageContext } = props;
   const position = props.data.syPersonioJob;
-  const socialCardImage = position.fields.socialCard;
+  const socialCardPath = position.socialCardFile.childImageSharp.fixed.src;
   const { t } = useTranslation();
 
   return (
     <>
       <SEO
-        shareImagePath={socialCardImage}
+        shareImagePath={socialCardPath}
         title={t('career.seo.title-detail', {
           name: position.name,
         })}
@@ -51,9 +51,6 @@ const CareerPage: React.FC<CareerPageProps> = (props): JSX.Element => {
 export const CareerDetailsPageQuery = graphql`
   query ($language: String!, $id: String!) {
     syPersonioJob(id: { eq: $id }) {
-      fields {
-        socialCard
-      }
       id
       lang
       jobId
@@ -65,6 +62,13 @@ export const CareerDetailsPageQuery = graphql`
         headline
         descriptionHtml
         description
+      }
+      socialCardFile {
+        childImageSharp {
+          fixed(width: 1440, height: 760) {
+            src
+          }
+        }
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,16 +40,22 @@ export interface SyPersonioJob {
   slug: string;
   sections: SyPersonioJobSection[];
 
-  // now owned by the source plugin, added via `onCreateNode`
-  fields: {
-    socialCard: string;
-  };
+  // added via `onCreateNode`
+  socialCardFile: PlainFixedImageSharpSource;
 }
 
 export interface SyTeamMember {
   id: string;
   name: string;
   image: IGatsbyImageData;
+}
+
+export interface PlainFixedImageSharpSource {
+  childImageSharp: {
+    fixed: {
+      src: string;
+    };
+  };
 }
 
 export interface BlogPostMarkdown {
@@ -61,13 +67,7 @@ export interface BlogPostMarkdown {
     };
   };
   frontmatter: {
-    shareImage: {
-      childImageSharp: {
-        fixed: {
-          src: string;
-        };
-      };
-    };
+    shareImage: PlainFixedImageSharpSource;
     attribution: {
       creator: string;
       source: string;


### PR DESCRIPTION
I have created a Gatsby PR to fix this situation for the future and other lost souls:
https://github.com/gatsbyjs/gatsby/pull/34313

---
This will change the social cards generation. Instead of writing directly into `public/` which happily works we move closer to the gatsby way of doing things by creating an actual file node. We can do this with `createFileNodeFromBuffer` from [gatsby-source-filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/). 

In order to save that node to our original node we can't just save the ID of the file in some fields. We need to tell gatsby about the foreign key relationship. This was usually done with the `myField___NODE` notation which is now deprecated.

That's why we have to create a custom graphql schema addition which is also included in there.

Preview:
https://satellytescommain21751-gkcardsbuffer.gtsb.io/

## Still works
We have swapped from file to buffer and the files are still work. You can see the switch after looking the the generated path `https://satellytescommain21751-gkcardsbuffer.gtsb.io/static/93ec6b3d62c7099eaea57bcea3aad6a6/468fb/social-card.jpg` 👍

via metatags.io
![Screen Shot 2021-12-23 at 11 23 06](https://user-images.githubusercontent.com/1701755/147226658-372bbbca-3989-484e-acbb-4b30285faa29.png)

![Screen Shot 2021-12-23 at 11 22 40](https://user-images.githubusercontent.com/1701755/147226647-bc24ef9f-c513-457a-b6ad-a06ad8109599.png)

## Insights
Another thing that we struggled a lot with: The created files are fine, but only on the initial build. Any incremental build (repeated starts of gatsby) throw away the files and the value were null then. We tried so many things because we didn't know why this was happening while using standard gatsby functions.

In the end the solution is a single line: `parentNodeId: node.id` which we pass in addition to `createFileNodeFromBuffer`. This solves the problem because now gatsby leaves the file as is. It seems they have been deleted before because gatsby though they are dangling files without an owner.

The problematic thing here is `createRemoteFileNode` requires the parent id while the `createFileNodeFromBuffer` happily set null as a default. I think that's a bug worth to submit with this feedback.

Here the referenced source for createFileNodeFromBuffer
https://github.com/gatsbyjs/gatsby/blob/b9f7749f36ace526bf0ba05b80731091cc0f2ceb/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js#L125

vs createRemoteFileNode
https://github.com/gatsbyjs/gatsby/blob/b9f7749f36ace526bf0ba05b80731091cc0f2ceb/packages/gatsby-source-filesystem/src/create-remote-file-node.js#L100

I also found this issue talking about a similar thing:
https://github.com/gatsbyjs/gatsby/issues/4537

referencing this PR but it's not really explaining thinks even though Kyle asked for that:
https://github.com/gatsbyjs/gatsby/pull/6793/files#diff-b746772e1ad7ebd3e0f347c527f10886ffd1f7e74eb29ee957f1d7946241781aR108-R121


The actual foreign key documentation can be found here:
https://www.gatsbyjs.com/docs/node-creation/

