### PR TITLE
feat: contact form via gatsby function

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@reach/accordion": "^0.16.1",
     "@reach/listbox": "^0.16.2",
     "@reach/tabs": "^0.16.4",
+    "@slack/web-api": "^6.5.1",
     "@svgr/webpack": "^6.1.2",
     "@types/leaflet": "^1.7.8",
     "axios": "^0.24.0",

--- a/src/api/contact-form.ts
+++ b/src/api/contact-form.ts
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+  console.log(`submitted form`, req.body);
+  res.status(200).json({ hello: `world` });
+}

--- a/src/api/contact-form.ts
+++ b/src/api/contact-form.ts
@@ -1,17 +1,95 @@
 import { WebClient, LogLevel } from '@slack/web-api';
 
-export default async function handler(req, res) {
-  const channelId = 'website';
+const TOKEN = process.env.SLACK_BOT_SY_TOKEN;
 
-  const client = new WebClient(process.env.SLACK_BOT_SY_TOKEN, {
+/**
+ * Easily build this block structure via https://app.slack.com/block-kit-builder
+ */
+const createSlackMessage = ({ name, email, message }) => {
+  return [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: 'New form submission',
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'We have received a new message.',
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `*Name*:\n ${name}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*E-mail*:\n ${email}`,
+        },
+      ],
+    },
+    {
+      type: 'divider',
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'plain_text',
+          text: message,
+        },
+      ],
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: 'Sent via _Satellytes Contact Form_',
+        },
+      ],
+    },
+  ];
+};
+
+export default async function handler(req, res) {
+  const { name, email, message, ...honey } = req.body;
+  console.log('receive form data', { name, email, message }, honey);
+
+  if (honey.firstName || honey.phone) {
+    console.log(`honeypot trap filled, aborting (received "${honey}")`);
+
+    // this is probably a bot as our honeypot fields have been filled
+    // let's silently ignore that bot
+    return res.status(200).json({ ok: true });
+  }
+
+  if (req.method !== `POST`) {
+    return res.status(500).json({ error: `not allowed` });
+  }
+
+  if (!TOKEN) {
+    return res.status(500).json({ error: `no slack token given` });
+  }
+
+  const channelId = 'website';
+  const client = new WebClient(TOKEN, {
     logLevel: LogLevel.DEBUG,
   });
 
   try {
-    // Call the chat.postMessage method using the WebClient
     const result = await client.chat.postMessage({
       channel: channelId,
-      text: 'Hello world',
+      // raw text as the fallback content for notifications.
+      text: `${name} (${email}) sent the following message:\n ${message}`,
+      blocks: createSlackMessage({ name, email, message }),
+      icon_emoji: ':inbox_tray:',
     });
 
     console.log(result);
@@ -19,6 +97,5 @@ export default async function handler(req, res) {
     console.error(error);
   }
 
-  console.log(`submitted form`, req.body);
-  res.status(200).json({ hello: `world` });
+  return res.status(200).json({ ok: true });
 }

--- a/src/api/contact-form.ts
+++ b/src/api/contact-form.ts
@@ -1,4 +1,5 @@
 import { WebClient, LogLevel } from '@slack/web-api';
+import { GatsbyFunctionRequest, GatsbyFunctionResponse } from 'gatsby';
 
 const TOKEN = process.env.SLACK_BOT_SY_TOKEN;
 
@@ -58,7 +59,10 @@ const createSlackMessage = ({ name, email, message }) => {
   ];
 };
 
-export default async function handler(req, res) {
+export default async function handler(
+  req: GatsbyFunctionRequest,
+  res: GatsbyFunctionResponse,
+) {
   const { name, email, message, ...honey } = req.body;
   console.log('receive form data', { name, email, message }, honey);
 

--- a/src/api/contact-form.ts
+++ b/src/api/contact-form.ts
@@ -1,4 +1,24 @@
-export default function handler(req, res) {
+import { WebClient, LogLevel } from '@slack/web-api';
+
+export default async function handler(req, res) {
+  const channelId = 'website';
+
+  const client = new WebClient(process.env.SLACK_BOT_SY_TOKEN, {
+    logLevel: LogLevel.DEBUG,
+  });
+
+  try {
+    // Call the chat.postMessage method using the WebClient
+    const result = await client.chat.postMessage({
+      channel: channelId,
+      text: 'Hello world',
+    });
+
+    console.log(result);
+  } catch (error) {
+    console.error(error);
+  }
+
   console.log(`submitted form`, req.body);
   res.status(200).json({ hello: `world` });
 }

--- a/src/components/pages/contact/contact-form.tsx
+++ b/src/components/pages/contact/contact-form.tsx
@@ -18,6 +18,7 @@ import { CheckmarkIcon } from '../../legacy/icons/form-icons/checkmark';
 import { RightArrowIcon } from '../../legacy/icons/form-icons/right-arrow';
 
 type RequestStatus = 'pending' | 'success' | 'error';
+const API_ENDPOINT = '/api/contact-form';
 
 const StyledCaptionText = styled(CaptionText)`
   color: inherit;
@@ -49,7 +50,7 @@ export const ContactForm: React.FC = () => {
         .join('&');
     };
 
-    fetch('/', {
+    fetch(API_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: encodeForNetlify({ 'form-name': 'contact', ...formData }),
@@ -68,13 +69,7 @@ export const ContactForm: React.FC = () => {
   };
 
   return (
-    <form
-      name="contact"
-      method="POST"
-      data-netlify="true"
-      data-netlify-honeypot="bot-field"
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form name="contact" onSubmit={handleSubmit(onSubmit)}>
       <Grid nested>
         {/*First Name*/}
         <GridItem xs={12} md={6}>

--- a/src/components/pages/contact/contact-form.tsx
+++ b/src/components/pages/contact/contact-form.tsx
@@ -18,7 +18,7 @@ import { CheckmarkIcon } from '../../legacy/icons/form-icons/checkmark';
 import { RightArrowIcon } from '../../legacy/icons/form-icons/right-arrow';
 import { hideVisually } from 'polished';
 
-type RequestStatus = 'pending' | 'success' | 'error';
+type RequestStatus = 'pending' | 'submitting' | 'success' | 'error';
 const API_ENDPOINT = '/api/contact-form';
 
 const StyledCaptionText = styled(CaptionText)`
@@ -40,7 +40,6 @@ const MagicFieldContainer = styled.div`
   ${hideVisually()}
 `;
 const MagicField = ({ label, control }) => {
-  console.log({ control });
   return (
     <MagicFieldContainer>
       <label>
@@ -61,6 +60,8 @@ export const ContactForm: React.FC = () => {
   } = useForm();
 
   const onSubmit = (formData: FormData) => {
+    setRequestStatus('submitting');
+
     fetch(API_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/components/pages/contact/contact-form.tsx
+++ b/src/components/pages/contact/contact-form.tsx
@@ -16,7 +16,7 @@ import styled from 'styled-components';
 import { SIMPLE_EMAIL_PATTERN } from '../../legacy/form/constants';
 import { CheckmarkIcon } from '../../legacy/icons/form-icons/checkmark';
 import { RightArrowIcon } from '../../legacy/icons/form-icons/right-arrow';
-import { hideVisually } from 'polished';
+import { HoneypotField } from './honeypot';
 
 type RequestStatus = 'pending' | 'submitting' | 'success' | 'error';
 const API_ENDPOINT = '/api/contact-form';
@@ -29,26 +29,6 @@ interface FormData {
   email: string;
   message: string;
 }
-
-/**
- * This is a honeypot field but we want to disguise it including the wording
- * and hope the bots can't filter them by any heuristic
- * (hopefully ignoring this comment
- **/
-
-const MagicFieldContainer = styled.div`
-  ${hideVisually()}
-`;
-const MagicField = ({ label, control }) => {
-  return (
-    <MagicFieldContainer>
-      <label>
-        {label}
-        <input type="text" {...control} tabIndex={-1} autoComplete="false" />
-      </label>
-    </MagicFieldContainer>
-  );
-};
 
 export const ContactForm: React.FC = () => {
   const { t } = useTranslation();
@@ -123,8 +103,8 @@ export const ContactForm: React.FC = () => {
           />
         </GridItem>
 
-        <MagicField label="First Name" control={register('firstName')} />
-        <MagicField label="Phone" control={register('phone')} />
+        <HoneypotField label="First Name" control={register('firstName')} />
+        <HoneypotField label="Phone" control={register('phone')} />
 
         <GridItem>
           <StyledCaptionText>

--- a/src/components/pages/contact/honeypot.tsx
+++ b/src/components/pages/contact/honeypot.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+import { hideVisually } from 'polished';
+
+const HoneypotFieldContainer = styled.div`
+  ${hideVisually()}
+`;
+
+export const HoneypotField = ({ label, control }) => {
+  return (
+    <HoneypotFieldContainer>
+      <label>
+        {label}
+        <input type="text" {...control} tabIndex={-1} autoComplete="false" />
+      </label>
+    </HoneypotFieldContainer>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2558,6 +2558,35 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
+  dependencies:
+    "@types/node" ">=12.0.0"
+
+"@slack/types@^2.0.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.4.0.tgz#b6f6d50e9181f723080b841302e089739cef512d"
+  integrity sha512-0k8UlVEH9gUVwTbwcanS1JT2vCROkr1WESgdXW7d2maWYTuwbVEx87YvXPjsemAJfdu+RYqxGhO2oGTigprepA==
+
+"@slack/web-api@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.5.1.tgz#21a4f055cd7facf8d769cf62c61a40e37a3eb87c"
+  integrity sha512-W1PDIdHz/GtDpC8afpPUsXMfAQ+sZGwmfxx+Ug83uhRD8zECrypGTmIyCqrCSWzf2qVKT9XvMftZX3m0AmPY8A==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.0.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=12.0.0"
+    axios "^0.24.0"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-electron "2.2.0"
+    is-stream "^1.1.0"
+    p-queue "^6.6.1"
+    p-retry "^4.0.0"
+
 "@storybook/addon-actions@6.4.9", "@storybook/addon-actions@^6.4.9":
   version "6.4.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.4.9.tgz#1d4e8c00ad304efe6722043dac759f4716b515ee"
@@ -3877,6 +3906,13 @@
   resolved "https://registry.yarnpkg.com/@types/is-function/-/is-function-1.0.1.tgz#2d024eace950c836d9e3335a66b97960ae41d022"
   integrity sha512-A79HEEiwXTFtfY+Bcbo58M2GRYzCr9itHWzbzHVFNEYCcoU/MMGwYYf721gBrnhpj1s6RGVVha/IgNFnR0Iw/Q==
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -3984,6 +4020,11 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@17.0.8", "@types/node@>=10.0.0", "@types/node@^17.0.5":
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.8.tgz#50d680c8a8a78fe30abe6906453b21ad8ab0ad7b"
+  integrity sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==
+
+"@types/node@>=12.0.0":
   version "17.0.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.8.tgz#50d680c8a8a78fe30abe6906453b21ad8ab0ad7b"
   integrity sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==
@@ -4098,6 +4139,11 @@
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
+
+"@types/retry@^0.12.0":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
+  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
 "@types/rimraf@^2.0.2":
   version "2.0.5"
@@ -6154,7 +6200,7 @@ colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.2.tgz#cd4fe227412ca2c75bb6f5683ec2e5e68de4f317"
   integrity sha512-5QhJWPFZqkKIieXJPpCprdOytvH7v0AGWpu9K2jZ4LWkGg3dVBNoYPgGGRpEsc0jb8Boy0ElYrdjH9uXfhRSqw==
 
-combined-stream@^1.0.8:
+combined-stream@^1.0.6, combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -7937,7 +7983,7 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -8458,6 +8504,15 @@ form-data@4.0.0, form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 form-data@^3.0.0:
@@ -10584,6 +10639,11 @@ is-dom@^1.0.0:
   dependencies:
     is-object "^1.0.1"
     is-window "^1.0.2"
+
+is-electron@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -13486,12 +13546,28 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-queue@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@^4.0.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c"
+  integrity sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==
+  dependencies:
+    "@types/retry" "^0.12.0"
+    retry "^0.13.1"
+
 p-throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/p-throttle/-/p-throttle-4.1.1.tgz#80b1fbd358af40a8bfa1667f9dc8b72b714ad692"
   integrity sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==
 
-p-timeout@^3.1.0:
+p-timeout@^3.1.0, p-timeout@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
@@ -15439,6 +15515,11 @@ retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This will remove the netlify dependency for our form submission and closes #317 so we can move over to gatsby deployment entirely.

✅ The functionality is confirmed by submitting the form. Will be received in our website channel.

## Description
Added a "gatsby function" a small serverless function to forward our contact form submissions to our Slack with the help of `@slack/web-api`. I created a new slack bot for this, registered the Slack API token in the gatsby cloud and tested the message format in some hidden channel.

The API endpoint is available here:
https://satellytescommain21751-gkgatsbyfunctionsslack.gtsb.io/api/contact-form

And the form makes use of it:
https://satellytescommain21751-gkgatsbyfunctionsslack.gtsb.io/contact/

To prevent too many spam bots I wanted to deliver a small honeypot with this PR that shows some hidden fields to bots, that are hopefully filled with data so we can filter them. I didn't want to introduce a captcha with this change (Possible hcaptcha.com which is used by cloudflare)

I also had to introduce a new status for the form as we never blocked multiple submissions (double click and such).