### PR TITLE
fix: base url env typo

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ const BRANCH_PREVIEW_URL = buildGatsbyCloudPreviewUrl({
 
 // either use a branch preview url if any
 const BASE_URL =
-  BRANCH_PREVIEW_URL || process.env.GATBSY_BASE_UR || 'http://localhost:8000';
+  BRANCH_PREVIEW_URL || process.env.GATBSY_BASE_URL || 'http://localhost:8000';
 
 const LANGUAGES = ['en', 'de'];
 const DEFAULT_LANGUAGE = 'en';


### PR DESCRIPTION
It's a stupid typo that leads us to the localhost fallback on production. Our `buildGatsbyCloudPreviewUrl` is well tested but the actual `BASE_URL` construction is not tested and that's where the typo happened. I think it would be better to provide `buildBaseUrl` instead of focussing on the gatsby preview url part. That way we could test that part.

This is a hotfix and we should deliver the refactoring afterwards as we wasted too much time with small mistakes around the url building in the past already.