### PR TITLE
chore(deps): bump engine.io from 4.1.1 to 4.1.2 dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,5 @@ This is a demo post.
 Some text
 
 - some list item
-- some list item B
+- some list item
 ```

--- a/README.md
+++ b/README.md
@@ -72,5 +72,5 @@ This is a demo post.
 Some text
 
 - some list item
-- some list item
+- some list item B
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -7399,9 +7399,9 @@ engine.io-parser@~4.0.0, engine.io-parser@~4.0.1:
     base64-arraybuffer "0.1.4"
 
 engine.io@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-4.1.1.tgz#9a8f8a5ac5a5ea316183c489bf7f5b6cf91ace5b"
-  integrity sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-4.1.2.tgz#f96ceb56d4b39cc7ca5bd29a20e9c99c1ad1a765"
+  integrity sha512-t5z6zjXuVLhXDMiFJPYsPOWEER8B0tIsD3ETgw19S1yg9zryvUfY3Vhtk3Gf4sihw/bQGIqQ//gjvVlu+Ca0bQ==
   dependencies:
     accepts "~1.3.4"
     base64id "2.0.0"


### PR DESCRIPTION
mirror of #326 because gatsby failed to detect the PR so it's stuck.