### PR TITLE
fix: translate kicker in hero on career-details page

### DIFF
--- a/src/assets/locales/de/translations.json
+++ b/src/assets/locales/de/translations.json
@@ -34,6 +34,7 @@
   "career.remove-file": "Entfernen",
   "career.cv": "Lebenslauf",
   "career.other": "anderes",
+  "career.position": "Stelle",
   "career.info-text": "Lade hier bitte deine relevanten Dokumente hoch, wie zb Lebenslauf (CV), Motivationsschreiben oder Referenzen. Erlaubt sind ausschließlich 3 PDF Dateien, die maximale Größe pro Datei beträgt 20MB.",
   "career.privacy-policy": "<0>Hiermit bestätige ich, dass ich die <1>Datenschutzerklärung</1> zur Kenntnis genommen habe. <4>*</4></0>",
   "career.introduction.headline": "Arbeite mit uns",

--- a/src/assets/locales/en/translations.json
+++ b/src/assets/locales/en/translations.json
@@ -28,6 +28,7 @@
   "career.remove-file": "Remove",
   "career.cv": "CV",
   "career.other": "other",
+  "career.position": "position",
   "career.info-text": "Please upload relevant files e.g. CV, cover letter or references. You can upload 3 pdf-documents with a maximal size of 20 MB each.",
   "career.privacy-policy": "<0>I hereby confirm that i have taken note of the <1>privacy policy</1>.  <4>*</4></0>",
   "career.introduction.headline": "Work with us",

--- a/src/components/content/heroes/hero-text.tsx
+++ b/src/components/content/heroes/hero-text.tsx
@@ -33,6 +33,7 @@ const Kicker = styled.span`
   ${TextStyles.toplineR}
   display: block;
   margin-bottom: 16px;
+  text-transform: capitalize;
 `;
 
 const Headline = styled.h1`

--- a/src/components/pages/career-details/career-details.tsx
+++ b/src/components/pages/career-details/career-details.tsx
@@ -41,7 +41,7 @@ export const CareerDetails = ({
       transparentHeader={true}
       translation={complementPath}
       hero={
-        <AuroraHero kicker="Stelle" title={position.name}>
+        <AuroraHero kicker={t('career.position')} title={position.name}>
           {position.short}
         </AuroraHero>
       }


### PR DESCRIPTION
This PR adds a missing translation for the "Stelle" that appears in the Kicker in the Hero on the career-details page.

Screenshot from our currently live English website:
![image](https://user-images.githubusercontent.com/7970458/149764742-e12be2e0-847a-45b3-8a76-e301b9506f22.png)

I've added the `text-transform: capitalize;` style to the Kicker so the translation itself does not need to know about casing (`position` felt more correct in the English translations than `Position`).

### How to review
- Locally: Start the website locally with `yarn start` and navigate to any career details page. Make sure that the "Kicker" text is properly translated.
- Cloud: Look at the preview deployment https://satellytescommain21751-fixjobpositionkicker.gtsb.io/career/staff-software-engineer/ and make sure the "Kicker" text is properly translated.