### PR TITLE
fix: add image to blog description

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -196,6 +196,7 @@ module.exports = {
             `,
             output: RSS_FEED_URL,
             title: 'Satellytes',
+            image_url: 'https://satellytes.com/sy-share-image.jpg',
             // optional configuration to insert feed reference in pages:
             // if `string` is used, it will be used to create RegExp and then test if pathname of
             // current page satisfied this regular expression;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,14 +151,14 @@ module.exports = {
                     {
                       title: edge.node.frontmatter.title,
                       date: edge.node.frontmatter.date,
-                      description: `${edge.node.excerpt} ${imageHtml}`,
+                      description: edge.node.excerpt,
                       url:
                         site.siteMetadata.siteUrl + edge.node.frontmatter.path,
                       guid:
                         site.siteMetadata.siteUrl + edge.node.frontmatter.path,
                       custom_elements: [
                         {
-                          'content:encoded': edge.node.html,
+                          'content:encoded': `${imageUrl} ${edge.node.html}`,
                         },
                       ],
                     },


### PR DESCRIPTION
Feedly parses the description of a blog post to extract the image. Therefore we happen an image tag in every description. Let's see if it works with the deployed URL imported in Feedly.


**Update**
Appending it to the description doesn't work, will append it to the content

> If it works I will refactor the code