### PR TITLE
fix: add image to blog content

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -196,6 +196,7 @@ module.exports = {
             `,
             output: RSS_FEED_URL,
             title: 'Satellytes',
+            image_url: 'https://satellytes.com/sy-share-image.jpg',
             // optional configuration to insert feed reference in pages:
             // if `string` is used, it will be used to create RegExp and then test if pathname of
             // current page satisfied this regular expression;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,14 +29,7 @@ const SEO_EXCLUDED_URLS = [
 ];
 
 const RSS_FEED_URL = '/blog/rss.xml';
-
-const escapeHTML = (html) => {
-  return html
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-};
+const DEFAULT_META_IMAGE_URL_PATH = '/sy-share-image.jpg';
 
 module.exports = {
   siteMetadata: {
@@ -127,7 +120,6 @@ module.exports = {
                 title
                 description
                 siteUrl
-                site_url: siteUrl
               }
             }
           }
@@ -138,29 +130,25 @@ module.exports = {
               return allMarkdownRemark.edges
                 .filter((edge) => !edge.node.fields.slug.includes('/pages/'))
                 .map((edge) => {
+                  const blogPostMeta = edge.node.frontmatter;
                   const imageUrl =
-                    site.siteMetadata.siteUrl +
-                      edge.node.frontmatter.shareImage.childImageSharp.fixed
-                        .src || '/sy-share-image.jpg';
-                  const imageHtml = `<img src="${imageUrl}" alt=""/>`;
+                    BASE_URL +
+                    (blogPostMeta.shareImage.childImageSharp.fixed.src ||
+                      DEFAULT_META_IMAGE_URL_PATH);
 
-                  return Object.assign(
-                    {},
-                    {
-                      title: edge.node.frontmatter.title,
-                      date: edge.node.frontmatter.date,
-                      description: edge.node.excerpt,
-                      url:
-                        site.siteMetadata.siteUrl + edge.node.frontmatter.path,
-                      guid:
-                        site.siteMetadata.siteUrl + edge.node.frontmatter.path,
-                      custom_elements: [
-                        {
-                          'content:encoded': `${imageHtml} ${edge.node.html}`,
-                        },
-                      ],
-                    },
-                  );
+                  return {
+                    title: blogPostMeta.title,
+                    site_url: site.siteMetadata.siteUrl,
+                    date: blogPostMeta.date,
+                    description: edge.node.excerpt,
+                    url: site.siteMetadata.siteUrl + blogPostMeta.path,
+                    guid: site.siteMetadata.siteUrl + blogPostMeta.path,
+                    custom_elements: [
+                      {
+                        'content:encoded': `<img src='${imageUrl}' alt=''/> ${edge.node.html}`,
+                      },
+                    ],
+                  };
                 });
             },
             query: `
@@ -194,7 +182,7 @@ module.exports = {
             `,
             output: RSS_FEED_URL,
             title: 'Satellytes',
-            image_url: 'https://satellytes.com/sy-share-image.jpg',
+            image_url: BASE_URL + DEFAULT_META_IMAGE_URL_PATH,
             // optional configuration to insert feed reference in pages:
             // if `string` is used, it will be used to create RegExp and then test if pathname of
             // current page satisfied this regular expression;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,7 @@ module.exports = {
   siteMetadata: {
     title: 'Satellytes',
     description:
-      'Satellytes ist eine Digital-Agentur, die um große Unternehmen kreist und ihnen bei der Transformation und Optimierung digitaler Services und Interfaces hilft.',
+      'Passionate experts that strive to build the best possible and above all right solution for our clients and customers.',
     author: 'Satellytes',
     siteUrl: BASE_URL,
   },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -158,7 +158,7 @@ module.exports = {
                         site.siteMetadata.siteUrl + edge.node.frontmatter.path,
                       custom_elements: [
                         {
-                          'content:encoded': `${imageUrl} ${edge.node.html}`,
+                          'content:encoded': `${imageHtml} ${edge.node.html}`,
                         },
                       ],
                     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,14 +151,14 @@ module.exports = {
                     {
                       title: edge.node.frontmatter.title,
                       date: edge.node.frontmatter.date,
-                      description: `${edge.node.excerpt} ${imageHtml}`,
+                      description: edge.node.excerpt,
                       url:
                         site.siteMetadata.siteUrl + edge.node.frontmatter.path,
                       guid:
                         site.siteMetadata.siteUrl + edge.node.frontmatter.path,
                       custom_elements: [
                         {
-                          'content:encoded': edge.node.html,
+                          'content:encoded': `${imageUrl} ${edge.node.html}`,
                         },
                       ],
                     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -142,9 +142,7 @@ module.exports = {
                     site.siteMetadata.siteUrl +
                       edge.node.frontmatter.shareImage.childImageSharp.fixed
                         .src || '/sy-share-image.jpg';
-                  const imageHtml = escapeHTML(
-                    ` <img src="${imageUrl}" alt=""/>`,
-                  );
+                  const imageHtml = `<img src="${imageUrl}" alt=""/>`;
 
                   return Object.assign(
                     {},


### PR DESCRIPTION
Feedly parses the content of a blog post to extract the image. Some blog posts don't have an image in the content, so I added the title image right at the start of the content. Looks very cool in Feedly.

I'm not sure how other feed readers behave. The RSS standard doesn't have a simple image attribute for an item. I assume that they behave similarly. The popular [Golem RSS](https://rss.golem.de/rss.php?feed=RSS2.0) feed does it the same way.

<details>
<summary>Screenshot of the blog summary</summary>
<img width="904" alt="Screenshot 2022-01-25 at 08 09 39" src="https://user-images.githubusercontent.com/7814926/150928337-0bbce72f-7871-43c5-b296-efd39ac8a343.png">
</details>

<details>
<summary>Screenshot of the blog posts overview</summary>
<img width="772" alt="Screenshot 2022-01-25 at 08 10 19" src="https://user-images.githubusercontent.com/7814926/150928411-031e782d-8462-40f8-ab89-4834f92a368b.png">

</details>

<details>
<summary>Screenshot of a blog post</summary>
<img width="825" alt="Screenshot 2022-01-25 at 08 03 56" src="https://user-images.githubusercontent.com/7814926/150927526-5f3b4ea3-75b6-41fd-8ed6-13e23ad7f46d.png">
</details>

I also changed the Satellytes slogan in our `gatsby-config.js` to English, as this is the default language.

Fixes #335 
