### PR TITLE
feat: add redirect to our gather office

### DIFF
--- a/gatsby/create-pages/create-redirects.js
+++ b/gatsby/create-pages/create-redirects.js
@@ -39,6 +39,11 @@ const REDIRECTS = [
     fromPath: '/blog/scoped-registry/',
     toPath: '/blog/enterprises-benefit-from-scoped-npm-registries/',
   },
+  ,
+  {
+    fromPath: '/orion/',
+    toPath: '/api/redirect-gather-sy-office',
+  },
 ];
 
 /**
@@ -48,11 +53,6 @@ const REDIRECTS = [
  */
 const createRedirects = ({ actions }) => {
   const { createRedirect } = actions;
-
-  createRedirect({
-    fromPath: `/orion/`,
-    toPath: `/api/redirect-gather-sy-office`,
-  });
 
   REDIRECTS.forEach((redirect) => {
     createRedirect({

--- a/gatsby/create-pages/create-redirects.js
+++ b/gatsby/create-pages/create-redirects.js
@@ -49,6 +49,11 @@ const REDIRECTS = [
 const createRedirects = ({ actions }) => {
   const { createRedirect } = actions;
 
+  createRedirect({
+    fromPath: `/orion`,
+    toPath: `/api/redirect-gather-sy-office`,
+  });
+
   REDIRECTS.forEach((redirect) => {
     createRedirect({
       fromPath: redirect.fromPath,

--- a/gatsby/create-pages/create-redirects.js
+++ b/gatsby/create-pages/create-redirects.js
@@ -39,11 +39,6 @@ const REDIRECTS = [
     fromPath: '/blog/scoped-registry/',
     toPath: '/blog/enterprises-benefit-from-scoped-npm-registries/',
   },
-  ,
-  {
-    fromPath: '/orion/',
-    toPath: '/api/redirect-gather-sy-office',
-  },
 ];
 
 /**
@@ -53,6 +48,14 @@ const REDIRECTS = [
  */
 const createRedirects = ({ actions }) => {
   const { createRedirect } = actions;
+  /**
+   * Our vanity url to access our gather office through satellytes.com/orion
+   * This should be a temporary redirect and actually SEO should never pick this url up anyway.
+   */
+  createRedirect({
+    fromPath: `/orion/`,
+    toPath: `/api/redirect-gather-sy-office`,
+  });
 
   REDIRECTS.forEach((redirect) => {
     createRedirect({

--- a/gatsby/create-pages/create-redirects.js
+++ b/gatsby/create-pages/create-redirects.js
@@ -50,7 +50,7 @@ const createRedirects = ({ actions }) => {
   const { createRedirect } = actions;
 
   createRedirect({
-    fromPath: `/orion`,
+    fromPath: `/orion/`,
     toPath: `/api/redirect-gather-sy-office`,
   });
 

--- a/src/api/redirect-gather-sy-office.ts
+++ b/src/api/redirect-gather-sy-office.ts
@@ -1,0 +1,13 @@
+import { GatsbyFunctionRequest, GatsbyFunctionResponse } from 'gatsby';
+
+const GATHER_URL = `https://gather.town/app/ea0xvXaHYWuWurME/satellytes`;
+
+/*
+Provide an endpoint to redirect to our gather space. 
+ */
+export default async function handler(
+  req: GatsbyFunctionRequest,
+  res: GatsbyFunctionResponse,
+) {
+  return res.redirect(GATHER_URL);
+}


### PR DESCRIPTION
I would like to have a vanity url for our gather office. That way we can easily add the link to calendar invites and also invite other external folks. Our Gather space is protected by a password which means there is no risk to expose the url.

I have implemented a lambda function to redirect to the gather space and an additional redirect from the root of our website (which can't handle external urls).

Edit:
This will provide the vanity url http://satellytes.com/orion. I picked the name orion as it's an awesome [star constellation](https://en.wikipedia.org/wiki/Orion_(constellation)) and [nebula](https://en.wikipedia.org/wiki/Orion_Nebula) and sounds much more exicting than `virtual-office` or `gather`. I would like to give our gather space a name like `Orion` to so we are prepared for our hybrid times when we have to clarify where we are working (in the office or in orion).

