### PR TITLE
fix(career-form): make upload form accept names with special chars

### DIFF
--- a/src/components/pages/career-details/career-form/career-file-upload-type.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload-type.tsx
@@ -82,8 +82,13 @@ export const CareerFileUploadType = ({
   watch,
 }: CareerFileUploadTypeProps) => {
   const { t } = useTranslation();
-  const fileName = file.name.split('.');
-  const name = `category_select.${fileName[0]}`;
+  const fileName = file.name.split('.')[0];
+  /**
+   * Create a sanitized file id by replacing anything that's not a letter which can be safely used as an identifier.
+   * Without this, a valid filename like `a,b.pdf` (osx) will create an identifier to safely use as an internal name.
+   */
+  const fileId = fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+  const name = `category_select.${fileId}`;
   const selectedFileType = watch(name);
 
   const onChange = (event) => {
@@ -114,7 +119,7 @@ export const CareerFileUploadType = ({
         </StyledSelect>
         <SelectArrow />
       </SelectContainer>
-      {errors.category_select?.[fileName[0]] && (
+      {errors.category_select?.[fileId] && (
         <FormErrorWrapper>
           <FormError
             error={{ message: t<string>('career.error.selection') }}


### PR DESCRIPTION
close #346

I found the reason for the upload form to fail in the file type dropdown which relies on an implicit data structure that is build using the file names. If the file name contains a comma, this fails. 

The fix is to create a sanitized id from a name by replacing anything that is not an alphanumeric character. That's something internal and does not change the appearance.
