### PR TITLE
feat: skip netlify on dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 
 updates:
-  # npm should be used for npm and yarn
   - package-ecosystem: npm
     open-pull-requests-limit: 10
     directory: "/"
@@ -11,7 +10,7 @@ updates:
       time: "06:00"
       timezone: "Europe/Berlin"
     commit-message:
-      # we need to disable netlify as we don't have enough builds for all dependency updates
+      # we need to disable netlify as we don't have enough build minutes for all dependency updates
       # https://docs.netlify.com/site-deploys/manage-deploys/#skip-a-deploy
       prefix: "[skip netlify]"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
     commit-message:
       # we need to disable netlify as we don't have enough builds for all dependency updates
       # https://docs.netlify.com/site-deploys/manage-deploys/#skip-a-deploy

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
 version: 2
 
 updates:
+  # npm should be used for npm and yarn
   - package-ecosystem: npm
     open-pull-requests-limit: 10
     directory: "/"
     schedule:
       interval: "weekly"
       day: "sunday"
+    commit-message:
+      # we need to disable netlify as we don't have enough builds for all dependency updates
+      prefix: "[skip ci]"
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       day: "sunday"
     commit-message:
       # we need to disable netlify as we don't have enough builds for all dependency updates
-      prefix: "[skip ci]"
+      # https://docs.netlify.com/site-deploys/manage-deploys/#skip-a-deploy
+      prefix: "[skip netlify]"
     labels:
       - dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    # only run a manual build when the PR comes from gatsby
+    # as gatsby doesn't run on automated pull requests
+    if: ${{ github.event.label.name == 'dependencies' }}
+    name: Build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install
+        run: yarn
+
+      - name: Build
+        run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: Build
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, opened, synchronize, reopened ]
 
 jobs:
   build:
-    # only run a manual build when the PR comes from gatsby
+    # only run a manual build when the PR comes from Dependabot
     # as gatsby doesn't run on automated pull requests
-    if: ${{ github.event.label.name == 'dependencies' }}
+    if: contains(github.event.pull_request.labels.*.name, '<label_name>')
     name: Build
 
     runs-on: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
           node-version: '16'
 
       - name: Install
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     # only run a manual build when the PR comes from Dependabot
     # as gatsby doesn't run on automated pull requests
-    if: contains(github.event.pull_request.labels.*.name, '<label_name>')
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     name: Build
 
     runs-on: ubuntu-latest

--- a/.github/workflows/gatsby-cloud-build.yml
+++ b/.github/workflows/gatsby-cloud-build.yml
@@ -1,4 +1,4 @@
-name: Scheduled Deployment
+name: Gatsby Cloud Build
 
 on:
   # run this workflow manually from the Actions tab
@@ -14,5 +14,5 @@ jobs:
     env:
       GATSBY_BUILD_WEBHOOK_URL: ${{ secrets.GATSBY_BUILD_WEBHOOK_URL }}
     steps:
-      - name: Trigger deployment
+      - name: Trigger build and deployment
         run: curl -X POST $GATSBY_BUILD_WEBHOOK_URL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '16'
 
       - name: Install
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Unit tests
         run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 # Continues integration pipeline to test every branch.
 #
 
-name: CI
+name: Test
 
 on: pull_request
 
@@ -14,12 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
-      - uses: actions/setup-node@v2-beta
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '16'
+
       - name: Install
         run: yarn
+
       - name: Unit tests
         run: yarn test
       - name: Test types


### PR DESCRIPTION
Improvements needed for #366 

We have some problems with Dependabot that we need to solve with this PR:
- Dependabot creates a lot of PRs. For every PR, Netlfiy starts a build. The free tier is quite limited, so within a few days we would run out of it. That's why we disable Netlify builds in Dependabot PRs
- Gatsby Cloud doesn't run on automatically created PRs. Even worse: They idle in the PR checks and don't do anything. That's why we need to make them optional _for all PRs_. To know if the dependency update still breaks our build, we run the build with Github Actions (only for Dependabot PRs). The free tier should be large enough for that.

With this setup:
- Depndabot PRs will trigger automatic tests and build with Github Actions
- Manual PRs will trigger Gatsby Cloud builds, Netlify Builds for Storybook and tests with Github Actions

If we see this setup is working, we can also add automatic merges of Dependabot PRs.