### PR TITLE
feat: keep github actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,18 @@ updates:
       prefix: "[skip netlify]"
     labels:
       - dependencies
+
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 10
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    commit-message:
+      # we need to disable netlify as we don't have enough build minutes for all dependency updates
+      # https://docs.netlify.com/site-deploys/manage-deploys/#skip-a-deploy
+      prefix: "[skip netlify]"
+    labels:
+      - dependencies


### PR DESCRIPTION
By accident, I stumbled upon the Dependabot feature to also keep Github Actions up to date. That's a nice feature I didn't know exists.

Link to the docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot