### PR TITLE
chore: upgrade storybook-addon-gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "lint-staged": "12.2.0",
     "prettier": "2.5.1",
     "serve": "^13.0.2",
-    "storybook-addon-gatsby": "0.0.3",
+    "storybook-addon-gatsby": "^0.0.5",
     "storybook-react-i18next": "^1.0.17",
     "ts-jest": "^27.1.3",
     "typescript": "4.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16039,10 +16039,10 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.13.1.tgz#fae7b5bb9d35fc53dc61cd262df3abb2f6e59022"
   integrity sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==
 
-storybook-addon-gatsby@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/storybook-addon-gatsby/-/storybook-addon-gatsby-0.0.3.tgz#943e02eb293b8361b78a6162c16f34851e79c722"
-  integrity sha512-vePIGWxaDVxLT9CqF010CrCOTbxg7bTAGU4uIstDI05AYzB6EmU+sblypBKI4GEtVDDyHSo/hezW4868PTV49g==
+storybook-addon-gatsby@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/storybook-addon-gatsby/-/storybook-addon-gatsby-0.0.5.tgz#94f5b67bab8659d0248b65e60dabc3702818ce8b"
+  integrity sha512-18f8Kc6mx8mEFfqY2DgF9ayDfmM58+9IjJqIxGV4bA4r2EtB/Q1LDNELIJmpLLyA5NrSvECxCqzLu7jNBlWgmA==
 
 storybook-i18n@^1.0.11:
   version "1.0.11"


### PR DESCRIPTION
`storybook-addon-gatsby` is now fixed: https://github.com/prismicio-community/storybook-addon-gatsby/issues/6
