### PR TITLE
chore: bump react-form-hooks and update types

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.5.1",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "7.22.5",
+    "react-hook-form": "7.26.1",
     "react-i18next": "^11.15.3",
     "react-leaflet": "^3.2.5",
     "react-share": "^4.4.0",

--- a/src/components/pages/career-details/career-form/career-components.tsx
+++ b/src/components/pages/career-details/career-form/career-components.tsx
@@ -93,7 +93,7 @@ export const Fieldset = styled.fieldset`
 
 interface ActionsProps {
   tryAgainFn: () => void;
-  error: Error;
+  error?: Error;
   isSubmitting: boolean;
   fieldErrors: FieldErrors;
 }

--- a/src/components/pages/career-details/career-form/career-file-upload-type.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload-type.tsx
@@ -88,7 +88,7 @@ export const CareerFileUploadType = ({
    * Without this, a valid filename like `a,b.pdf` will cause an error.
    */
   const fileId = createFileId(file.name);
-  // TODO: CareerFormValues contains a list of keys in field `category_select` which we should reflect here
+  // TODO: CareerFormValue contains a list of keys in field `category_select` which we should reflect here
   const name: any = `category_select.${fileId}`;
   const selectedFileType = watch(name);
 

--- a/src/components/pages/career-details/career-form/career-file-upload-type.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload-type.tsx
@@ -3,7 +3,6 @@ import { FormError } from './career-components';
 import styled from 'styled-components';
 import {
   FieldErrors,
-  FieldValues,
   UseFormClearErrors,
   UseFormRegister,
   UseFormSetValue,
@@ -13,12 +12,13 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { up } from '../../../support/breakpoint';
 import { SelectArrow } from '../../../legacy/icons/form-icons/select-arrow';
 import { createFileId } from './utils';
+import { CareerFormValues } from './career-form';
 
 interface CareerFileUploadTypeProps {
-  setValue: UseFormSetValue<FieldValues>;
-  clearError: UseFormClearErrors<FieldValues>;
-  register: UseFormRegister<FieldValues>;
-  watch: UseFormWatch<FieldValues>;
+  setValue: UseFormSetValue<CareerFormValues>;
+  clearError: UseFormClearErrors<CareerFormValues>;
+  register: UseFormRegister<CareerFormValues>;
+  watch: UseFormWatch<CareerFormValues>;
   errors: FieldErrors;
   file: File;
 }
@@ -41,7 +41,7 @@ const StyledSelect = styled.select`
     width: unset;
     display: inline-block;
     min-width: 144px;
-    margin-top: 0px;
+    margin-top: 0;
   }
 `;
 
@@ -88,7 +88,8 @@ export const CareerFileUploadType = ({
    * Without this, a valid filename like `a,b.pdf` will cause an error.
    */
   const fileId = createFileId(file.name);
-  const name = `category_select.${fileId}`;
+  // TODO: CareerFormValues contains a list of keys in field `category_select` which we should reflect here
+  const name: any = `category_select.${fileId}`;
   const selectedFileType = watch(name);
 
   const onChange = (event) => {

--- a/src/components/pages/career-details/career-form/career-file-upload-type.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload-type.tsx
@@ -12,13 +12,13 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { up } from '../../../support/breakpoint';
 import { SelectArrow } from '../../../legacy/icons/form-icons/select-arrow';
 import { createFileId } from './utils';
-import { CareerFormValues } from './career-form';
+import { CareerFormValue } from './career-form';
 
 interface CareerFileUploadTypeProps {
-  setValue: UseFormSetValue<CareerFormValues>;
-  clearError: UseFormClearErrors<CareerFormValues>;
-  register: UseFormRegister<CareerFormValues>;
-  watch: UseFormWatch<CareerFormValues>;
+  setValue: UseFormSetValue<CareerFormValue>;
+  clearError: UseFormClearErrors<CareerFormValue>;
+  register: UseFormRegister<CareerFormValue>;
+  watch: UseFormWatch<CareerFormValue>;
   errors: FieldErrors;
   file: File;
 }

--- a/src/components/pages/career-details/career-form/career-file-upload.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload.tsx
@@ -7,7 +7,6 @@ import styled, { css } from 'styled-components';
 import { theme } from '../../../layout/theme';
 import {
   FieldErrors,
-  FieldValues,
   UseFormClearErrors,
   UseFormRegister,
   UseFormSetError,
@@ -20,15 +19,14 @@ import { FormError } from './career-components';
 import { CareerFileUploadType } from './career-file-upload-type';
 import { rgba } from 'polished';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-
-type FormUploadValues = any;
+import { CareerFormValues } from './career-form';
 
 interface FileUploadProps {
-  setValue: UseFormSetValue<FormUploadValues>;
-  setError: UseFormSetError<FormUploadValues>;
-  clearErrors: UseFormClearErrors<FormUploadValues>;
-  register: UseFormRegister<FormUploadValues>;
-  watch: UseFormWatch<FormUploadValues>;
+  setValue: UseFormSetValue<CareerFormValues>;
+  setError: UseFormSetError<CareerFormValues>;
+  clearErrors: UseFormClearErrors<CareerFormValues>;
+  register: UseFormRegister<CareerFormValues>;
+  watch: UseFormWatch<CareerFormValues>;
   name: string;
   selectedFiles: FileList;
   errors: FieldErrors;

--- a/src/components/pages/career-details/career-form/career-file-upload.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload.tsx
@@ -21,12 +21,14 @@ import { CareerFileUploadType } from './career-file-upload-type';
 import { rgba } from 'polished';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 
+type FormUploadValues = any;
+
 interface FileUploadProps {
-  setValue: UseFormSetValue<FieldValues>;
-  setError: UseFormSetError<FieldValues>;
-  clearErrors: UseFormClearErrors<FieldValues>;
-  register: UseFormRegister<FieldValues>;
-  watch: UseFormWatch<FieldValues>;
+  setValue: UseFormSetValue<FormUploadValues>;
+  setError: UseFormSetError<FormUploadValues>;
+  clearErrors: UseFormClearErrors<FormUploadValues>;
+  register: UseFormRegister<FormUploadValues>;
+  watch: UseFormWatch<FormUploadValues>;
   name: string;
   selectedFiles: FileList;
   errors: FieldErrors;

--- a/src/components/pages/career-details/career-form/career-file-upload.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload.tsx
@@ -27,7 +27,7 @@ interface FileUploadProps {
   clearErrors: UseFormClearErrors<CareerFormValues>;
   register: UseFormRegister<CareerFormValues>;
   watch: UseFormWatch<CareerFormValues>;
-  name: string;
+  name: 'documents';
   selectedFiles: FileList;
   errors: FieldErrors;
   children: ReactNode | ReactNode[];

--- a/src/components/pages/career-details/career-form/career-file-upload.tsx
+++ b/src/components/pages/career-details/career-form/career-file-upload.tsx
@@ -19,14 +19,14 @@ import { FormError } from './career-components';
 import { CareerFileUploadType } from './career-file-upload-type';
 import { rgba } from 'polished';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { CareerFormValues } from './career-form';
+import { CareerFormValue } from './career-form';
 
 interface FileUploadProps {
-  setValue: UseFormSetValue<CareerFormValues>;
-  setError: UseFormSetError<CareerFormValues>;
-  clearErrors: UseFormClearErrors<CareerFormValues>;
-  register: UseFormRegister<CareerFormValues>;
-  watch: UseFormWatch<CareerFormValues>;
+  setValue: UseFormSetValue<CareerFormValue>;
+  setError: UseFormSetError<CareerFormValue>;
+  clearErrors: UseFormClearErrors<CareerFormValue>;
+  register: UseFormRegister<CareerFormValue>;
+  watch: UseFormWatch<CareerFormValue>;
   name: 'documents';
   selectedFiles: FileList;
   errors: FieldErrors;

--- a/src/components/pages/career-details/career-form/career-form.tsx
+++ b/src/components/pages/career-details/career-form/career-form.tsx
@@ -269,7 +269,7 @@ export const CareerForm = (props: CareerFormProps) => {
 
           {/*File-Upload*/}
           <FileUpload
-            name={'documents'}
+            name="documents"
             setValue={setValue}
             clearErrors={clearErrors}
             register={register}

--- a/src/components/pages/career-details/career-form/career-form.tsx
+++ b/src/components/pages/career-details/career-form/career-form.tsx
@@ -32,6 +32,10 @@ interface CareerFormProps {
   scrollToStart?: () => void;
 }
 
+interface CategorySelect {
+  [key: string]: string;
+}
+
 export type CareerFormValues = {
   first_name: string;
   last_name: string;
@@ -39,10 +43,8 @@ export type CareerFormValues = {
   documents: FileList;
   message: string;
   phone?: string;
-  category_select: any;
-
-  privacy: any;
-
+  category_select?: CategorySelect;
+  privacy: boolean;
   location: string;
   available_from: string;
   salary_expectations: string;
@@ -70,7 +72,7 @@ const InfoTextContainer = styled.div`
   display: flex;
   align-items: flex-start;
   flex-direction: row;
-  margin: 24px 0px;
+  margin: 24px 0;
   line-height: 24px;
 `;
 
@@ -147,6 +149,8 @@ export const CareerForm = (props: CareerFormProps) => {
     }
   }, [selectedFiles]);
 
+  console.log(watch('category_select'));
+
   const onSubmitHandler: SubmitHandler<CareerFormValues> = async (
     formValues,
   ): Promise<void> => {
@@ -158,7 +162,6 @@ export const CareerForm = (props: CareerFormProps) => {
       );
       return;
     }
-
     if (!privacyChecked) {
       setError(
         'privacy',
@@ -187,10 +190,13 @@ export const CareerForm = (props: CareerFormProps) => {
         for (let i = 0; i < formValues.documents.length; i++) {
           const keyName = `categorised_documents[${i}][file]`;
           const fileId = createFileId(formValues.documents[i].name);
-          const category = formValues.category_select[fileId];
+          const category = formValues.category_select?.[fileId];
           formData.append(keyName, formValues.documents[i]);
           const nameCategory = `categorised_documents[${i}][category]`;
-          formData.append(nameCategory, category);
+
+          if (category) {
+            formData.append(nameCategory, category);
+          }
         }
       } else {
         formData.append(key, value as any); // formdata doesn't take objects

--- a/src/components/pages/career-details/career-form/career-form.tsx
+++ b/src/components/pages/career-details/career-form/career-form.tsx
@@ -149,8 +149,6 @@ export const CareerForm = (props: CareerFormProps) => {
     }
   }, [selectedFiles]);
 
-  console.log(watch('category_select'));
-
   const onSubmitHandler: SubmitHandler<CareerFormValues> = async (
     formValues,
   ): Promise<void> => {
@@ -271,9 +269,9 @@ export const CareerForm = (props: CareerFormProps) => {
 
           {/*File-Upload*/}
           <FileUpload
+            name={'documents'}
             setValue={setValue}
             clearErrors={clearErrors}
-            name="documents"
             register={register}
             selectedFiles={selectedFiles}
             errors={errors}

--- a/src/components/pages/career-details/career-form/career-form.tsx
+++ b/src/components/pages/career-details/career-form/career-form.tsx
@@ -36,7 +36,7 @@ interface CategorySelect {
   [key: string]: string;
 }
 
-export type CareerFormValues = {
+export type CareerFormValue = {
   first_name: string;
   last_name: string;
   email: string;
@@ -136,7 +136,7 @@ export const CareerForm = (props: CareerFormProps) => {
     watch,
     setValue,
     formState: { errors, isSubmitSuccessful, isSubmitting },
-  } = useForm<CareerFormValues & FormErrors>();
+  } = useForm<CareerFormValue & FormErrors>();
 
   const { t } = useTranslation();
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -149,7 +149,7 @@ export const CareerForm = (props: CareerFormProps) => {
     }
   }, [selectedFiles]);
 
-  const onSubmitHandler: SubmitHandler<CareerFormValues> = async (
+  const onSubmitHandler: SubmitHandler<CareerFormValue> = async (
     formValues,
   ): Promise<void> => {
     if (selectedFiles?.length === 0) {

--- a/src/components/pages/career-details/career-form/career-textfields.tsx
+++ b/src/components/pages/career-details/career-form/career-textfields.tsx
@@ -4,10 +4,10 @@ import { FieldValues, UseFormRegister } from 'react-hook-form';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { SIMPLE_EMAIL_PATTERN } from '../../../forms/constants';
 import { InputField } from '../../../legacy/form/controls';
-import { CareerFormValues } from './career-form';
+import { CareerFormValue } from './career-form';
 
 interface CareerTextFieldsProps {
-  register: UseFormRegister<CareerFormValues>;
+  register: UseFormRegister<CareerFormValue>;
   errors: FieldValues;
 }
 

--- a/src/components/pages/career-details/career-form/career-textfields.tsx
+++ b/src/components/pages/career-details/career-form/career-textfields.tsx
@@ -4,9 +4,10 @@ import { FieldValues, UseFormRegister } from 'react-hook-form';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { SIMPLE_EMAIL_PATTERN } from '../../../forms/constants';
 import { InputField } from '../../../legacy/form/controls';
+import { CareerFormValues } from './career-form';
 
 interface CareerTextFieldsProps {
-  register: UseFormRegister<FieldValues>;
+  register: UseFormRegister<CareerFormValues>;
   errors: FieldValues;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14537,10 +14537,10 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@7.22.5:
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.22.5.tgz#85a135f3c5ae02ccf73096a03fc14b45607e9baa"
-  integrity sha512-Q2zaeQFXdVQ8l3hcywhltH+Nzj4vo50wMVujHDVN/1Xy9IOaSZJwYBXA2CYTpK6rq41fnXviw3jTLb04c7Gu9Q==
+react-hook-form@7.26.1:
+  version "7.26.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.26.1.tgz#8f5c0aa81a452f5ebcb6a2d7253800011e735b1c"
+  integrity sha512-/Qw/7IsCCVfYSGryJAMcouEpIDgWZJPeHR15J0IFSgo1BgofcfnY+AeUDcYD1E3yzzXYpR7NHyJehhkBKvjdMg==
 
 react-i18next@^11.15.3:
   version "11.15.3"


### PR DESCRIPTION
# Description
I went into the rabbit hole of updating the react form hooks package which refined the types at some point that revealed some issues in our current form code. I think it does not only reveal typing issues but the actual mess we have inside the career form component.

I managed to fix the types. I think the code should still work as I only focused on types and at some point I made the code more rigid by removing the flexibility to define a form name and instead hard code it  (`documents` in the upload component). This was was required as I didn't want to tinker around with typing programming (if this is feasible anyway in this context). I pinned the type to the string value `documents` because of that.

The most changes come from swapping the generic `FieldValues` type with our concrete `CareerFormValues` type. This creates some hard dependencies but to be honest, the components around the career from are one spaghetti plate anyway so this was a good way to fix the type issues while we still benefit from the types in the future

Speaking of the future: We should refactor that mess. This is not a failure of our juniors who mostly build that, but we missed the opportunity to refactor together with them from time to time I guess. Let's tackle this when we have some spare time. It's actually a nice challenge.

# How to review
Let's test the career submission at least once. As said technically nothing changed in the data structure but we have to make that sure.