### PR TITLE
fix: accordion design issues

### DIFF
--- a/src/components/pages/career/application-process.tsx
+++ b/src/components/pages/career/application-process.tsx
@@ -3,9 +3,18 @@ import { Accordion, AccordionSection } from '../../ui/accordion/accordion';
 import styled from 'styled-components';
 import { SectionHeader } from '../../content/section-header/section-header';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { up } from '../../support/breakpoint';
 
 const Spacer = styled.div`
   margin-bottom: 48px;
+`;
+
+const AccordionWrapper = styled.div`
+  margin: 0 -24px;
+
+  ${up('sm')} {
+    margin: 0;
+  }
 `;
 
 export const ApplicationProcess = () => {
@@ -18,33 +27,35 @@ export const ApplicationProcess = () => {
 
       <Spacer />
 
-      <Accordion defaultIndex={0}>
-        <AccordionSection
-          title={t('career.application-process.accordion.0.title')}
-          illustration={'scientistB_007'}
-        >
-          {t('career.application-process.accordion.0.paragraph')}
-        </AccordionSection>
+      <AccordionWrapper>
+        <Accordion defaultIndex={0}>
+          <AccordionSection
+            title={t('career.application-process.accordion.0.title')}
+            illustration={'scientistB_007'}
+          >
+            {t('career.application-process.accordion.0.paragraph')}
+          </AccordionSection>
 
-        <AccordionSection
-          title={t('career.application-process.accordion.1.title')}
-          illustration={'astronaut_015'}
-        >
-          {t('career.application-process.accordion.1.paragraph')}
-        </AccordionSection>
+          <AccordionSection
+            title={t('career.application-process.accordion.1.title')}
+            illustration={'astronaut_015'}
+          >
+            {t('career.application-process.accordion.1.paragraph')}
+          </AccordionSection>
 
-        <AccordionSection
-          title={t('career.application-process.accordion.2.title')}
-        >
-          {t('career.application-process.accordion.2.paragraph')}
-        </AccordionSection>
+          <AccordionSection
+            title={t('career.application-process.accordion.2.title')}
+          >
+            {t('career.application-process.accordion.2.paragraph')}
+          </AccordionSection>
 
-        <AccordionSection
-          title={t('career.application-process.accordion.3.title')}
-        >
-          {t('career.application-process.accordion.3.paragraph')}
-        </AccordionSection>
-      </Accordion>
+          <AccordionSection
+            title={t('career.application-process.accordion.3.title')}
+          >
+            {t('career.application-process.accordion.3.paragraph')}
+          </AccordionSection>
+        </Accordion>
+      </AccordionWrapper>
     </>
   );
 };

--- a/src/components/pages/career/application-process.tsx
+++ b/src/components/pages/career/application-process.tsx
@@ -20,6 +20,8 @@ const AccordionWrapper = styled.div`
 
 const AccordionText = styled.p`
   ${TextStyles.textR}
+  margin-top: 12px;
+  margin-bottom: -3px;
 `;
 
 export const ApplicationProcess = () => {

--- a/src/components/pages/career/application-process.tsx
+++ b/src/components/pages/career/application-process.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { SectionHeader } from '../../content/section-header/section-header';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { up } from '../../support/breakpoint';
+import { TextStyles } from '../../typography';
 
 const Spacer = styled.div`
   margin-bottom: 48px;
@@ -15,6 +16,10 @@ const AccordionWrapper = styled.div`
   ${up('sm')} {
     margin: 0;
   }
+`;
+
+const AccordionText = styled.p`
+  ${TextStyles.textR}
 `;
 
 export const ApplicationProcess = () => {
@@ -33,26 +38,34 @@ export const ApplicationProcess = () => {
             title={t('career.application-process.accordion.0.title')}
             illustration={'scientistB_007'}
           >
-            {t('career.application-process.accordion.0.paragraph')}
+            <AccordionText>
+              {t('career.application-process.accordion.0.paragraph')}
+            </AccordionText>
           </AccordionSection>
 
           <AccordionSection
             title={t('career.application-process.accordion.1.title')}
             illustration={'astronaut_015'}
           >
-            {t('career.application-process.accordion.1.paragraph')}
+            <AccordionText>
+              {t('career.application-process.accordion.1.paragraph')}
+            </AccordionText>
           </AccordionSection>
 
           <AccordionSection
             title={t('career.application-process.accordion.2.title')}
           >
-            {t('career.application-process.accordion.2.paragraph')}
+            <AccordionText>
+              {t('career.application-process.accordion.2.paragraph')}
+            </AccordionText>
           </AccordionSection>
 
           <AccordionSection
             title={t('career.application-process.accordion.3.title')}
           >
-            {t('career.application-process.accordion.3.paragraph')}
+            <AccordionText>
+              {t('career.application-process.accordion.3.paragraph')}
+            </AccordionText>
           </AccordionSection>
         </Accordion>
       </AccordionWrapper>

--- a/src/components/ui/accordion/accordion-animated-panel.tsx
+++ b/src/components/ui/accordion/accordion-animated-panel.tsx
@@ -4,12 +4,17 @@ import styled from 'styled-components';
 import { useAccordionItemContext } from '@reach/accordion';
 import { useDivHeight } from './use-div-height';
 import React from 'react';
+import { up } from '../../support/breakpoint';
 
 const AnimatedAccordionPanel = animated(ReachAccordion.AccordionPanel);
 const AnimatedPanelContainer = styled.div`
   padding-bottom: 16px;
   padding-left: 24px;
   padding-right: 24px;
+
+  ${up('sm')} {
+    padding-bottom: 0;
+  }
 `;
 
 /**

--- a/src/components/ui/accordion/accordion-header.tsx
+++ b/src/components/ui/accordion/accordion-header.tsx
@@ -37,7 +37,7 @@ const AccordionButton = styled(ReachAccordion.AccordionButton)`
 
   display: flex;
   align-items: center;
-  padding: 24px 20px;
+  padding: 0 24px;
 `;
 
 const StyledIcon = styled(Icon)<StyledIconProps>`

--- a/src/components/ui/accordion/accordion.tsx
+++ b/src/components/ui/accordion/accordion.tsx
@@ -37,6 +37,7 @@ export interface AccordionSectionProps {
 }
 
 const AccordionItem = styled(ReachAccordion.AccordionItem)`
+  padding: 20px 0;
   border-top: 1px solid #eeeeee;
 
   &:last-of-type {
@@ -51,14 +52,16 @@ const PanelContainer = styled.div`
 `;
 
 const PanelIllustration = styled(Illustration)`
-  padding-right: 1em;
+  margin-top: 16px;
+  margin-bottom: 4px;
   box-sizing: content-box;
-  float: left;
 
   ${up('sm')} {
     margin-left: auto;
-    padding-right: 0;
     padding-left: 36px;
+    margin-top: 12px;
+    margin-bottom: 0;
+
     /**
     Prevent the illustration from changing it's size due to shrinking and growing being a flex child here
     **/


### PR DESCRIPTION
Resolves: https://github.com/satellytes/satellytes.com/issues/354
Preview URL: https://satellytescommain21751-fixaccordionlayout.gtsb.io/career/

**What's included?**
- On mobile, the career accordion has no left/right margin now
- The `Text R` font style is applied to the accordion text 

<img width="390" alt="Bildschirmfoto 2022-02-08 um 14 45 51" src="https://user-images.githubusercontent.com/57712895/152999549-e709504e-c838-409b-9bdc-da48530351a3.png">
