### PR TITLE
chore: set correct theme color

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -214,7 +214,7 @@ module.exports = {
         short_name: 'Satellytes',
         start_url: '/',
         background_color: '#FFFFFF',
-        theme_color: '#668CFF',
+        theme_color: '#3E61EE',
         display: 'minimal-ui',
         icon: 'data/favicon.png', // This path is relative to the root of the site.
       },


### PR DESCRIPTION
#### What is included?
- This changes the `theme-color` meta tag using our gatsby-plugin-manifest
- In that way safari changes its header/tab bar color like mentioned in #392 

##### Design:
![image](https://user-images.githubusercontent.com/78978542/153579956-c5876ba6-ecc6-4bd5-b7b4-6d240321e404.png)

##### Solution
![image](https://user-images.githubusercontent.com/78978542/153580142-98d3cea3-33d3-4936-9b16-e42cdd620f5b.png)


