### PR TITLE
chore: remove hero on career detail page

### DIFF
--- a/src/components/pages/career-details/career-details.tsx
+++ b/src/components/pages/career-details/career-details.tsx
@@ -39,7 +39,6 @@ export const CareerDetails = ({
     <Layout
       siteTitleUrl="/career/"
       light={true}
-      transparentHeader={true}
       translation={complementPath}
       breadcrumb={breadcrumb}
       showLanguageSwitch={Boolean(complementPath)}

--- a/src/components/pages/career-details/career-details.tsx
+++ b/src/components/pages/career-details/career-details.tsx
@@ -4,7 +4,8 @@ import { CareerForm } from './career-form/career-form';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { JobDescription } from './job-description';
 import { SyPersonioJob } from '../../../types';
-import { AuroraHero } from '../../content/heroes';
+import { SectionHeader } from '../../content/section-header/section-header';
+import { ContentBlockContainer } from '../../layout/content-block-container';
 
 interface CareerDetailsProps {
   originalPath: string;
@@ -40,14 +41,15 @@ export const CareerDetails = ({
       light={true}
       transparentHeader={true}
       translation={complementPath}
-      hero={
-        <AuroraHero kicker={t('career.position')} title={position.name}>
-          {position.short}
-        </AuroraHero>
-      }
       breadcrumb={breadcrumb}
       showLanguageSwitch={Boolean(complementPath)}
     >
+      <ContentBlockContainer>
+        <SectionHeader headline={position.name} kicker={t('career.position')}>
+          {position.short}
+        </SectionHeader>
+      </ContentBlockContainer>
+
       <JobDescription sections={position.sections} />
 
       <CareerForm

--- a/src/components/pages/career-details/job-description.tsx
+++ b/src/components/pages/career-details/job-description.tsx
@@ -27,7 +27,7 @@ const PersonioHtml = styled.div`
     padding-left: 0;
 
     > li:before {
-      content: '·';
+      content: '-';
       position: absolute;
       top: 0;
       bottom: 0;


### PR DESCRIPTION
#### What is inculeded?
- remove hero on career detail pages
- add the job description from the hero to the "body"

![image](https://user-images.githubusercontent.com/78978542/153586836-028ef215-9c09-487b-8cf1-39e7dfc638fb.png)

closes #395 