### PR TITLE
feat: improve SEO with static date and more sitemap data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -257,6 +257,7 @@ module.exports = {
           allSitePage {
             nodes {
               path
+              pageContext
             }
           }
         }`,

--- a/gatsby/create-pages/create-blog-posts.js
+++ b/gatsby/create-pages/create-blog-posts.js
@@ -15,6 +15,7 @@ const createBlogPosts = async ({ actions, reporter, graphql }) => {
         nodes {
           frontmatter {
             path
+            date
           }
         }
       }
@@ -31,7 +32,9 @@ const createBlogPosts = async ({ actions, reporter, graphql }) => {
     createPage({
       path: appendTrailingSlash(node.frontmatter.path),
       component: BLOG_POST_TEMPLATE_PATH,
-      context: {},
+      context: {
+        publicationDate: node.frontmatter.date,
+      },
     });
   });
 };

--- a/gatsby/create-pages/create-blog-posts.js
+++ b/gatsby/create-pages/create-blog-posts.js
@@ -33,6 +33,7 @@ const createBlogPosts = async ({ actions, reporter, graphql }) => {
       path: appendTrailingSlash(node.frontmatter.path),
       component: BLOG_POST_TEMPLATE_PATH,
       context: {
+        // used for the sitemap
         publicationDate: node.frontmatter.date,
       },
     });

--- a/gatsby/gatsby-plugin-sitemap/__snapshots__/gatsby-plugin-sitemap.test.js.snap
+++ b/gatsby/gatsby-plugin-sitemap/__snapshots__/gatsby-plugin-sitemap.test.js.snap
@@ -3,6 +3,8 @@
 exports[`Gatsby Plugin Sitemap works 1`] = `
 Array [
   Object {
+    "changefreq": "daily",
+    "lastmod": undefined,
     "links": Array [
       Object {
         "lang": "en",
@@ -13,9 +15,12 @@ Array [
         "url": "/de/some-page/",
       },
     ],
+    "priority": 0.8,
     "url": "/some-page/",
   },
   Object {
+    "changefreq": "daily",
+    "lastmod": undefined,
     "links": Array [
       Object {
         "lang": "en",
@@ -26,24 +31,31 @@ Array [
         "url": "/de/some-page/",
       },
     ],
+    "priority": 0.8,
     "url": "/de/some-page/",
   },
   Object {
+    "changefreq": "daily",
+    "lastmod": undefined,
     "links": Array [
       Object {
         "lang": "de",
         "url": "/de/only-german/",
       },
     ],
+    "priority": 0.8,
     "url": "/de/only-german/",
   },
   Object {
+    "changefreq": "daily",
+    "lastmod": undefined,
     "links": Array [
       Object {
         "lang": "en",
         "url": "/only-default/",
       },
     ],
+    "priority": 0.8,
     "url": "/only-default/",
   },
 ]

--- a/gatsby/gatsby-plugin-sitemap/gatsby-plugin-sitemap.js
+++ b/gatsby/gatsby-plugin-sitemap/gatsby-plugin-sitemap.js
@@ -135,7 +135,7 @@ function gatsbyPluginSitemap({ allSitePage: { nodes: allPages } }) {
 }
 
 function serialize(sitemapItem) {
-  const HIGH_PRIO =
+  const FREQUENTLY_UPDATED =
     sitemapItem.path.includes('/blog') ||
     sitemapItem.path.includes('/career') ||
     sitemapItem.path === '/' ||
@@ -155,7 +155,7 @@ function serialize(sitemapItem) {
     // there is a lot of fuzz about changefreq and priority, some even say it
     // doesn't have any effect at all. so let's use a very simple definition
     changefreq: 'daily',
-    priority: HIGH_PRIO ? 1 : 0.8,
+    priority: FREQUENTLY_UPDATED ? 1 : 0.8,
 
     // publicationDate is optional and won't be rendered if not present
     lastmod: sitemapItem.publicationDate,

--- a/gatsby/gatsby-plugin-sitemap/gatsby-plugin-sitemap.js
+++ b/gatsby/gatsby-plugin-sitemap/gatsby-plugin-sitemap.js
@@ -129,7 +129,7 @@ function gatsbyPluginSitemap({ allSitePage: { nodes: allPages } }) {
       lang: languageKey,
       path,
       links,
-      publicationDate: pageContext.publicationDate,
+      publicationDate: pageContext?.publicationDate,
     };
   });
 }

--- a/gatsby/gatsby-plugin-sitemap/gatsby-plugin-sitemap.test.js
+++ b/gatsby/gatsby-plugin-sitemap/gatsby-plugin-sitemap.test.js
@@ -100,6 +100,9 @@ describe('Gatsby Plugin Sitemap', () => {
 
       expect(result).toEqual({
         url: '/some-page/',
+        priority: 0.8,
+        lastmod: undefined,
+        changefreq: 'daily',
         links: [
           {
             lang: 'en',

--- a/src/components/i18n-helpers.ts
+++ b/src/components/i18n-helpers.ts
@@ -1,6 +1,7 @@
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { format, parseISO } from 'date-fns';
 import { enGB, de } from 'date-fns/locale';
+
 /**
  * A custom  hook to read the current language
  * and return a formatter (date-fns) with the correct locale set
@@ -26,4 +27,8 @@ export const useLocaleFormat = (dateFormat) => {
       return null;
     }
   };
+};
+
+export const useLocaleDateFormatter = () => {
+  return useLocaleFormat('dd. MMMM yyyy');
 };

--- a/src/components/i18n-helpers.ts
+++ b/src/components/i18n-helpers.ts
@@ -2,6 +2,8 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { format, parseISO } from 'date-fns';
 import { enGB, de } from 'date-fns/locale';
 
+export const LONG_DATE_FORMAT = 'dd. MMMM yyyy';
+
 /**
  * A custom  hook to read the current language
  * and return a formatter (date-fns) with the correct locale set
@@ -27,8 +29,4 @@ export const useLocaleFormat = (dateFormat) => {
       return null;
     }
   };
-};
-
-export const useLocaleDateFormatter = () => {
-  return useLocaleFormat('dd. MMMM yyyy');
 };

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -12,6 +12,7 @@ import { BlogHero } from '../../content/heroes/blog-hero';
 import { BlogHeader } from '../../content/blog-header/blog-header';
 import { formatDistanceToNow } from 'date-fns';
 import { enGB } from 'date-fns/locale';
+import { useLocaleDateFormatter } from '../../i18n-helpers';
 
 interface BlogPostPageProps {
   markdown: BlogPostMarkdown;
@@ -30,6 +31,8 @@ const PanelContainer = styled.div`
 
 export const BlogPostPage = ({ markdown, breadcrumb }: BlogPostPageProps) => {
   const { t } = useTranslation();
+  const dateFormatter = useLocaleDateFormatter();
+
   const fm = markdown.frontmatter;
   const fields = markdown.fields;
 
@@ -43,10 +46,7 @@ export const BlogPostPage = ({ markdown, breadcrumb }: BlogPostPageProps) => {
     },
   };
 
-  const dateInWords = formatDistanceToNow(new Date(fm.date), {
-    locale: enGB,
-    addSuffix: true,
-  });
+  const dateInWords = dateFormatter(fm.date);
 
   const readingTime = `${Math.ceil(
     parseInt(fields.readingTime.minutes),

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -10,8 +10,6 @@ import { up } from '../../support/breakpoint';
 import { BlogPostMarkdown, BreadcrumbEntry } from '../../../types';
 import { BlogHero } from '../../content/heroes/blog-hero';
 import { BlogHeader } from '../../content/blog-header/blog-header';
-import { formatDistanceToNow } from 'date-fns';
-import { enGB } from 'date-fns/locale';
 import { useLocaleDateFormatter } from '../../i18n-helpers';
 
 interface BlogPostPageProps {

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -10,7 +10,7 @@ import { up } from '../../support/breakpoint';
 import { BlogPostMarkdown, BreadcrumbEntry } from '../../../types';
 import { BlogHero } from '../../content/heroes/blog-hero';
 import { BlogHeader } from '../../content/blog-header/blog-header';
-import { useLocaleDateFormatter } from '../../i18n-helpers';
+import { LONG_DATE_FORMAT, useLocaleFormat } from '../../i18n-helpers';
 
 interface BlogPostPageProps {
   markdown: BlogPostMarkdown;
@@ -29,7 +29,7 @@ const PanelContainer = styled.div`
 
 export const BlogPostPage = ({ markdown, breadcrumb }: BlogPostPageProps) => {
   const { t } = useTranslation();
-  const dateFormatter = useLocaleDateFormatter();
+  const dateFormatter = useLocaleFormat(LONG_DATE_FORMAT);
 
   const fm = markdown.frontmatter;
   const fields = markdown.fields;
@@ -44,13 +44,13 @@ export const BlogPostPage = ({ markdown, breadcrumb }: BlogPostPageProps) => {
     },
   };
 
-  const dateInWords = dateFormatter(fm.date);
+  const formattedDate = dateFormatter(fm.date);
 
   const readingTime = `${Math.ceil(
     parseInt(fields.readingTime.minutes),
   )}min read`;
   const byLine = `${fm.author} (${fm.authorSummary})`;
-  const heroByLine = `${dateInWords} • ${readingTime} • ${byLine}`;
+  const heroByLine = `${formattedDate} • ${readingTime} • ${byLine}`;
 
   return (
     <Layout

--- a/src/components/pages/blog/posts.tsx
+++ b/src/components/pages/blog/posts.tsx
@@ -1,4 +1,4 @@
-import { useLocaleDateFormatter } from '../../i18n-helpers';
+import { LONG_DATE_FORMAT, useLocaleFormat } from '../../i18n-helpers';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
@@ -20,7 +20,7 @@ interface PostsProps {
 }
 
 export const Posts = ({ posts }: PostsProps) => {
-  const dateFormatter = useLocaleDateFormatter();
+  const dateFormatter = useLocaleFormat(LONG_DATE_FORMAT);
 
   return (
     <BlogTeaserGrid>

--- a/src/components/pages/blog/posts.tsx
+++ b/src/components/pages/blog/posts.tsx
@@ -1,4 +1,4 @@
-import { useLocaleFormat } from '../../i18n-helpers';
+import { useLocaleDateFormatter } from '../../i18n-helpers';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
@@ -20,7 +20,7 @@ interface PostsProps {
 }
 
 export const Posts = ({ posts }: PostsProps) => {
-  const dateFormatter = useLocaleFormat('dd. MMMM yyyy');
+  const dateFormatter = useLocaleDateFormatter();
 
   return (
     <BlogTeaserGrid>

--- a/src/components/pages/landingpage/blog.tsx
+++ b/src/components/pages/landingpage/blog.tsx
@@ -4,7 +4,7 @@ import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
 import { HomePageHeaderBlock } from './support';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
-import { useLocaleFormat } from '../../i18n-helpers';
+import { useLocaleDateFormatter } from '../../i18n-helpers';
 import { BlogPostTeaser } from '../../../types';
 import styled from 'styled-components';
 import { Button } from '../../ui/buttons/button';
@@ -19,7 +19,7 @@ const Spacer = styled.div`
 
 export const Blog = ({ posts }: BlogProps) => {
   const { t } = useTranslation();
-  const dateFormatter = useLocaleFormat('dd. MMMM yyyy');
+  const dateFormatter = useLocaleDateFormatter();
 
   return (
     <>

--- a/src/components/pages/landingpage/blog.tsx
+++ b/src/components/pages/landingpage/blog.tsx
@@ -4,7 +4,7 @@ import { Teaser } from '../../content/teaser/teaser';
 import React from 'react';
 import { HomePageHeaderBlock } from './support';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
-import { useLocaleDateFormatter } from '../../i18n-helpers';
+import { LONG_DATE_FORMAT, useLocaleFormat } from '../../i18n-helpers';
 import { BlogPostTeaser } from '../../../types';
 import styled from 'styled-components';
 import { Button } from '../../ui/buttons/button';
@@ -19,7 +19,7 @@ const Spacer = styled.div`
 
 export const Blog = ({ posts }: BlogProps) => {
   const { t } = useTranslation();
-  const dateFormatter = useLocaleDateFormatter();
+  const dateFormatter = useLocaleFormat(LONG_DATE_FORMAT);
 
   return (
     <>


### PR DESCRIPTION
Some pages are not indexed by Google. We are not sure why, as they are technically fine. But there are some small things we can improve. Those things are:

- Render the blog post publication date fixed. The date was previously rendered relative (at least if it's less than 1 month). This could be bad for SEO and it results in a flickering message because the string is different when the build is older than a day. 
<img width="189" alt="Screenshot 2022-02-14 at 15 46 11" src="https://user-images.githubusercontent.com/7814926/153885870-539f877d-388c-4a3d-a67d-de7e232e5b11.png">

- Add some meta tags to the sitemap. `priority` and `changefreq` are a bit esoteric, I just adopted the same values we use for other customers. The `lastmod` date is only used on blog posts.

Let's hope those 2 fixes improve our SEO score and make some of the missing pages accessible on Google.

Test URLS:
- Blog Post: https://satellytescommain21751-featimproveseo.gtsb.io/blog/cloudfront-cache-efficiency/
- Sitemap: https://satellytescommain21751-featimproveseo.gtsb.io/sitemap/sitemap-0.xml

Relates to #343