### PR TITLE
chore: remove language switch from header

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -7,7 +7,6 @@ import { CloseBurgerMenuIcon } from '../../legacy/icons/header-icons/close-burge
 import { NavigationFlyout } from './menu-flyout';
 import { Link } from '../../legacy/links/links';
 import { Swoosh } from '../../legacy/icons/header-icons/swoosh';
-import { LanguageSwitch } from './language-switch';
 import { HEADER_HEIGHT_VALUE } from '../theme';
 
 export const HEADER_HEIGHT = `${HEADER_HEIGHT_VALUE}px`;
@@ -171,12 +170,6 @@ const Header: React.FC<HeaderProps> = (props) => {
         {props.siteTitle}
       </SiteTitle>
       <Wrapper>
-        {(props.translation || props.showLanguageSwitch) && (
-          <LanguageSwitch
-            translation={props.translation}
-            $lightTheme={Boolean(!isHeaderTransparent && props.$lightTheme)}
-          />
-        )}
         <SiteMenu
           aria-label="Open menu"
           $lightTheme={Boolean(!isHeaderTransparent && props.$lightTheme)}

--- a/src/components/layout/header/language-switch.tsx
+++ b/src/components/layout/header/language-switch.tsx
@@ -22,10 +22,9 @@ const StyledSelection = styled.select`
   ${TextStyles.menuMeta};
   background: none;
   border: none;
-  text-align: right;
 
   color: inherit;
-  padding-left: 14px;
+  padding-left: 18px;
 
   appearance: none;
   cursor: pointer;

--- a/src/components/layout/header/language-switch.tsx
+++ b/src/components/layout/header/language-switch.tsx
@@ -1,104 +1,60 @@
 import { useI18next } from 'gatsby-plugin-react-i18next';
 import React from 'react';
-import styled, { DefaultTheme } from 'styled-components';
-import { Dropdown, DropdownOption } from '../../forms/dropdown/dropdown';
+import styled from 'styled-components';
 import { Icon } from '../../ui/icon/icon';
+import { theme } from '../theme';
+import { TextStyles } from '../../typography';
 
 interface LanguageSwitchProps {
   translation: any;
   className?: string;
-  $lightTheme?: boolean;
-  fromNavigation?: boolean;
 }
 
-const getTextColor = ({
-  fromNavigation,
-  $lightTheme,
-  theme,
-}: {
-  fromNavigation?: boolean;
-  $lightTheme?: boolean;
-  theme: DefaultTheme;
-}) => {
-  if (fromNavigation || $lightTheme) {
-    return theme.palette.text.header.light;
-  } else {
-    return theme.palette.text.header.default;
-  }
-};
-
-const getTextHoverColor = ({
-  fromNavigation,
-  $lightTheme,
-  theme,
-}: {
-  fromNavigation?: boolean;
-  $lightTheme?: boolean;
-  theme: DefaultTheme;
-}) => {
-  if (fromNavigation || $lightTheme) {
-    return theme.palette.text.header.hover;
-  } else if (!$lightTheme) {
-    return theme.palette.text.header.default;
-  }
-};
-
-const StyledNav = styled.nav<{
-  $lightTheme?: boolean;
-  fromNavigation?: boolean;
-}>`
+const StyledNav = styled.nav`
   transition: color 0.2s;
-  color: ${(props) => getTextColor(props)};
+  color: ${theme.palette.text.default};
   &:hover {
-    color: ${(props) => getTextHoverColor(props)};
+    color: ${theme.palette.text.defaultLight};
   }
-  display: flex;
-  align-items: center;
 `;
 
-const StyledSelection = styled(Dropdown)`
-  cursor: pointer;
-  text-transform: uppercase;
-  font-weight: bold;
-  font-size: 14px;
+const StyledSelection = styled.select`
+  ${TextStyles.menuMeta};
+  background: none;
+  border: none;
+  text-align: right;
+
   color: inherit;
-  padding: 4px 0 0 10px;
+  padding-left: 14px;
+
+  appearance: none;
+  cursor: pointer;
 `;
 
-const StyledIcon = styled(Icon)`
-  /*margin-right: -15px makes the Caret clickable*/
-  margin-right: -15px;
+export const StyledChevron = styled(Icon)`
+  cursor: pointer;
+  /*margin-right: -22px makes the Chevron clickable*/
+  margin-right: -22px;
 `;
 
 export const LanguageSwitch = ({
   className = 'language-switch',
-  $lightTheme,
-  fromNavigation,
 }: LanguageSwitchProps) => {
   const { languages, language, t, changeLanguage } = useI18next();
 
   return (
-    <StyledNav
-      aria-label={t('navigation.language-aria')}
-      className={className}
-      $lightTheme={$lightTheme}
-      fromNavigation={fromNavigation}
-    >
-      <StyledIcon show="caret_squared_down" />
+    <StyledNav aria-label={t('navigation.language-aria')} className={className}>
+      <StyledChevron show="caret_squared_down" />
       <StyledSelection
-        onChange={(selectedOption) => {
-          changeLanguage(selectedOption);
+        onChange={(event) => {
+          changeLanguage(event.target.value);
         }}
         value={language}
       >
         {languages.map((languageOfLink) => (
-          <DropdownOption
-            value={languageOfLink}
-            key={languageOfLink}
-            label={languageOfLink}
-          >
-            {languageOfLink == 'de' ? 'Deutsch' : 'English'}
-          </DropdownOption>
+          <option value={languageOfLink} key={languageOfLink}>
+            {languageOfLink === 'en' ? t('navigation.en') : t('navigation.de')}
+          </option>
         ))}
       </StyledSelection>
     </StyledNav>

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -147,7 +147,7 @@ export const Layout = ({
           </LeadboxFooterContainer>
         )}
         <footer>
-          <Navigation />
+          <Navigation showLanguageSwitch={showLanguageSwitch} />
         </footer>
       </FullHeightContainer>
     </ThemeProvider>

--- a/src/components/layout/navigation/navigation.tsx
+++ b/src/components/layout/navigation/navigation.tsx
@@ -124,6 +124,7 @@ const LegalLink = styled(Link)<{ $isSelected: boolean }>`
   /**
    * necessary for Safari
    */
+
   &:link {
     color: ${(props) => (props.$isSelected ? '#ffffff' : '#202840')};
   }
@@ -267,7 +268,6 @@ const Navigation: React.FC<NavigationProps> = ({
                 <LanguageSwitchWrapper
                   translation={translation}
                   className={'language-switch'}
-                  fromNavigation
                 />
               )}
               <nav>

--- a/src/components/layout/navigation/navigation.tsx
+++ b/src/components/layout/navigation/navigation.tsx
@@ -93,6 +93,7 @@ const SocialLinks = styled.ul`
 
   ${up('md')} {
     order: 1;
+    margin-left: 1px;
     margin-bottom: 24px;
   }
 `;


### PR DESCRIPTION
Resolves [#416 ](https://github.com/satellytes/satellytes.com/issues/351)
Preview: https://satellytescommain21751-choreheaderlanguageswitch.gtsb.io/

What's included?
- The language switch (and its header color logic) is removed from the header
- The language switch in the navigation is displayed in the flyout and footer version
- The language switch is a native `select` again
- Since I worked in the navigation anyway, I adjusted the margin of the social links by 1px

<img width="313" alt="Bildschirmfoto 2022-02-15 um 10 43 26" src="https://user-images.githubusercontent.com/57712895/154035687-26ee5287-4827-45e8-bbef-928e8df75979.png">
