### PR TITLE
chore: provide teaser text for older blog posts

### DIFF
--- a/blog-posts/angular-inject-the-injector.md
+++ b/blog-posts/angular-inject-the-injector.md
@@ -6,6 +6,7 @@ featuredImage: images/georgios-kaleadis-aBTfTMsOCOI-unsplash.jpg
 author: Georgios Kaleadis
 authorSummary: "CTO at Satellytes"
 seoMetaText: A coding pattern to prevent breaking changes when dealing with injections in base classes used in distributed libraries
+teaserText: A coding pattern to prevent breaking changes when dealing with injections in base classes used in distributed libraries
 attribution:
     creator: Georgios Kaleadis
     source: https://unsplash.com/photos/aBTfTMsOCOI

--- a/blog-posts/angular-workshop-2019.md
+++ b/blog-posts/angular-workshop-2019.md
@@ -3,7 +3,8 @@ path: "/blog/angular-workshop-kaiserx-allianz-2018/"
 date: "2018-12-01"
 title: Angular Advanced Workshop (2018)
 featuredImage: images/angular.png
-seoMetaText: Our Open Source 3-day Angular Advanced Workshop we conducted for KaiserX (Allianz). 
+seoMetaText: Our Open Source 3-day Angular Advanced Workshop we conducted for KaiserX (Allianz).
+teaserText: Our Open Source 3-day Angular Advanced Workshop we conducted for KaiserX (Allianz).
 author: Georgios Kaleadis
 authorSummary: CTO at Satellytes
 ---

--- a/blog-posts/monorepo-code-owner.md
+++ b/blog-posts/monorepo-code-owner.md
@@ -3,6 +3,7 @@ path: "/blog/monorepo-codeowner-github-enterprise/"
 date: "2021-07-09"
 title: Every big monorepo needs the CODEOWNERS feature
 featuredImage: images/chang-duong-Sj0iMtq_Z4w-unsplash.jpg
+teaserText: Find out what you gain by defining ownership of your files.
 seoMetaText: CODEOWNERS file help to split the code responsibilities & ownership in a monorepo.
 attribution:
    creator: Chang Duong

--- a/blog-posts/optimze-gatsby-urls.md
+++ b/blog-posts/optimze-gatsby-urls.md
@@ -6,6 +6,8 @@ featuredImage: images/how-to-optimize-gatsby-url-hero.jpeg
 author: "Fabian Dietenberger"
 authorSummary: "Senior Developer at Satellytes"
 leadboxText: Have you learned something about Gatsby? Then join us to learn more!
+teaserText: We did a deep dive into how to work with URLs in Gatsby to improve UX and search engine ranking.
+seoMetaText: We did a deep dive into how to work with URLs in Gatsby to improve UX and search engine ranking.
 attribution:
     creator: Jonny Clow 
     source: https://unsplash.com/photos/FwMBtl6IQQA

--- a/blog-posts/typescript-ast-type-checker.md
+++ b/blog-posts/typescript-ast-type-checker.md
@@ -3,6 +3,7 @@ path: "/blog/typescript-ast-type-checker/"
 date: "2021-06-18"
 title: "Going beyond the Abstract Syntax Tree (AST) with the TypeScript Type Checker"
 seoMetaText: How to analyze a typescript file beyond the Abstract Syntax Tree (AST) with the TS type checking utility "checker.ts"
+teaserText: How to analyze a typescript file beyond the Abstract Syntax Tree (AST) with the TS type checking utility "checker.ts"
 author: Georgios Kaleadis
 authorSummary: "CTO at Satellytes"
 featuredImage: images/johann-siemens-EPy0gBJzzZU-unsplash.jpg


### PR DESCRIPTION
I added some missing teaser texts to our older blog posts. 

before:
![Screenshot 2022-02-15 at 11 28 32](https://user-images.githubusercontent.com/1701755/154046742-33819fce-80fd-4aa2-aaa3-b7da2c41888a.png)


after:
![Screenshot 2022-02-15 at 11 28 49](https://user-images.githubusercontent.com/1701755/154046631-d9f31cd6-fd41-4dca-b20a-15532144eb02.png)

