### PR TITLE
fix: add some redirects that are still in the google index

### DIFF
--- a/gatsby/create-pages/create-redirects.js
+++ b/gatsby/create-pages/create-redirects.js
@@ -36,8 +36,16 @@ const REDIRECTS = [
     toPath: '/de/imprint/',
   },
   {
+    fromPath: '/office/',
+    toPath: '/about-us/',
+  },
+  {
     fromPath: '/blog/scoped-registry/',
     toPath: '/blog/enterprises-benefit-from-scoped-npm-registries/',
+  },
+  {
+    fromPath: '/de/blog/monorepo-codeowner-github-enterprise/',
+    toPath: '/blog/monorepo-codeowner-github-enterprise/',
   },
 ];
 


### PR DESCRIPTION
Checking the Google Search Console, I found those 2 links that are still in the index but show a 404 page. I created a redirect to the correct page.

The change is trivial. Feel free to click on `merge` once approved.