### PR TITLE
fix(Blog): ordered list alignment

### DIFF
--- a/src/components/legacy/markdown/custom-components.tsx
+++ b/src/components/legacy/markdown/custom-components.tsx
@@ -34,9 +34,9 @@ const UnorderedList = styled.ul`
   }
 `;
 
-const OrderedList = styled.ol`
+const OrderedList = styled.ol<{ doubleDigit: boolean }>`
   line-height: 150%;
-  padding-left: 18px;
+  padding-left: ${(props) => (props.doubleDigit ? '26px' : '18px')};
 
   > li {
     margin-bottom: 12px;
@@ -161,7 +161,11 @@ const customSatellytesComponents = {
     return <SmallTitle as={'h6'}>{props.children}</SmallTitle>;
   },
   ol(props) {
-    return <OrderedList>{props.children}</OrderedList>;
+    return (
+      <OrderedList doubleDigit={props.children.length > 9}>
+        {props.children}
+      </OrderedList>
+    );
   },
   ul(props) {
     return <UnorderedList>{props.children}</UnorderedList>;

--- a/src/components/legacy/markdown/custom-components.tsx
+++ b/src/components/legacy/markdown/custom-components.tsx
@@ -36,7 +36,7 @@ const UnorderedList = styled.ul`
 
 const OrderedList = styled.ol`
   line-height: 150%;
-  padding-left: 16px;
+  padding-left: 18px;
 
   > li {
     margin-bottom: 12px;


### PR DESCRIPTION
Resolves: https://github.com/satellytes/satellytes.com/issues/436

**What's included?**
* the right margin of ordered lists in blogposts is decreased by `2px`
* edge case behavior for lists with two digits 

**Preview**
Normal:
<img width="946" alt="Bildschirmfoto 2022-03-07 um 09 43 35" src="https://user-images.githubusercontent.com/57712895/156998747-3f14f70b-2c88-4cbd-976e-f0ec206d2674.png">
Two Digits:
<img width="949" alt="Bildschirmfoto 2022-03-07 um 09 42 36" src="https://user-images.githubusercontent.com/57712895/156998735-c992120b-95d4-4582-b629-548e7f5bf40f.png">

