### PR TITLE
feat: remove legacy in Blog component

### DIFF
--- a/src/components/pages/blog/not-avilable-in-german.tsx
+++ b/src/components/pages/blog/not-avilable-in-german.tsx
@@ -1,7 +1,6 @@
 import { useI18next } from 'gatsby-plugin-react-i18next';
-import { ButtonText, SendButton } from '../../legacy/form/controls';
-import { RightArrowIcon } from '../../legacy/icons/form-icons/right-arrow';
 import React from 'react';
+import { Button } from '../../ui/buttons/button';
 
 /**
  * This is deliberately without i18n as it's a Germany-only
@@ -17,9 +16,7 @@ export const NotAvailableInGerman = () => {
   return (
     <div>
       <p>Der Blog ist nur auf Englisch verfügbar.</p>
-      <SendButton onClick={switchToEnglish}>
-        <ButtonText>Zum Blog</ButtonText> <RightArrowIcon />
-      </SendButton>
+      <Button onClick={switchToEnglish}>Zum Blog</Button>
     </div>
   );
 };


### PR DESCRIPTION
### What is included?
- This will remove the legacy components in a Blog component.
- Those legacy components are defined in the old career form files
- This PR will make the Career form PR #398 smaller

### It looks still fine:
![image](https://user-images.githubusercontent.com/78978542/159687758-bdf5f12d-6922-4d9f-ad03-499df2f18c75.png)

