### PR TITLE
feat: use explicite CENTER value for image crop

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -64,6 +64,7 @@ export const BlogPageQuery = graphql`
                 aspectRatio: 1.77
                 layout: CONSTRAINED
                 placeholder: BLURRED
+                transformOptions: { cropFocus: CENTER }
               )
             }
           }


### PR DESCRIPTION
### Resolves
Removes randomness for cropping images for blog post overview. 
[By default the focus-point is set to "attention"](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/#transformoptions) which may produce unintended results esp. for images without a clear central element. 

### Can be tested
* https://satellytescommain21751-featblogoverviewimagecenter.gtsb.io/blog 

Compare to https://satellytes.com/blog (esp. notable on first image)