### PR TITLE
feat: add medium zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-hook-form": "7.28.1",
     "react-i18next": "^11.16.1",
     "react-leaflet": "^3.2.5",
+    "react-medium-image-zoom": "^4.3.5",
     "react-share": "^4.4.0",
     "react-spring": "^9.4.4",
     "react-use": "^17.3.2",

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -17,6 +17,8 @@ import { MarkdownAst } from '../../legacy/markdown/markdown-ast';
 import { up } from '../../support/breakpoint';
 import FollowPanel from './follow-panel';
 import SharePanel from './share-panel';
+import Zoom from 'react-medium-image-zoom';
+import 'react-medium-image-zoom/dist/styles.css';
 
 interface BlogPostPageProps {
   blogPost: BlogArticleQueryData;
@@ -95,18 +97,12 @@ const contentfulRenderOptions: Options = {
         case 'image': {
           return customComponents.figure({
             children: [
-              customComponents.a({
-                key: 'link',
-                children: (
-                  <GatsbyImage
-                    image={node.data.target.gatsbyImageData}
-                    alt={node.data.target.description}
-                  />
-                ),
-                href: node.data.target.file.url,
-                target: '_blank',
-                rel: 'nofollow noopener noreferrer',
-              }),
+              <Zoom key={node.data.target.file.url}>
+                <GatsbyImage
+                  image={node.data.target.gatsbyImageData}
+                  alt={node.data.target.description}
+                />
+              </Zoom>,
               customComponents.figcaption({
                 key: 'figcaption',
                 children: node.data.target.description,

--- a/src/components/ui/image/image.tsx
+++ b/src/components/ui/image/image.tsx
@@ -4,8 +4,6 @@ import styled, { css } from 'styled-components';
 import { up } from '../../support/breakpoint';
 import { theme } from '../../layout/theme';
 import { TextStyles } from '../../typography';
-import Zoom from 'react-medium-image-zoom';
-import 'react-medium-image-zoom/dist/styles.css';
 
 const mapTextAlignToFlex = (textAlign: 'right' | 'left' | 'bottom') => {
   if (textAlign === 'right') {
@@ -98,7 +96,7 @@ export const Image = ({
   return (
     <BlockWrapper textPlacement={textAlign}>
       <ImageWrapper>
-        <Zoom>{children}</Zoom>
+        {children}
         {attribution && (
           <AttributionContainer>
             <Trans i18nKey="image.attribution">Photo by </Trans>

--- a/src/components/ui/image/image.tsx
+++ b/src/components/ui/image/image.tsx
@@ -4,6 +4,8 @@ import styled, { css } from 'styled-components';
 import { up } from '../../support/breakpoint';
 import { theme } from '../../layout/theme';
 import { TextStyles } from '../../typography';
+import Zoom from 'react-medium-image-zoom';
+import 'react-medium-image-zoom/dist/styles.css';
 
 const mapTextAlignToFlex = (textAlign: 'right' | 'left' | 'bottom') => {
   if (textAlign === 'right') {
@@ -96,7 +98,7 @@ export const Image = ({
   return (
     <BlockWrapper textPlacement={textAlign}>
       <ImageWrapper>
-        {children}
+        <Zoom>{children}</Zoom>
         {attribution && (
           <AttributionContainer>
             <Trans i18nKey="image.attribution">Photo by </Trans>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8972,6 +8972,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
+focus-options-polyfill@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/focus-options-polyfill/-/focus-options-polyfill-1.2.0.tgz#9800ffb230bc9db63eea6d27694a62ac2e355946"
+  integrity sha512-4sgXxV/zU4WHM2IHWpjUmEWazbF6ie+M93/uo8ipfAbQ1GHopn+/V+Ca+PR0ndxswNQbisCNrjbnvWEq14MkTA==
+
 follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
@@ -15435,6 +15440,15 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-medium-image-zoom@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/react-medium-image-zoom/-/react-medium-image-zoom-4.3.5.tgz#9ed82faf73a68ba4ce76d8f94c022fc555eec4e4"
+  integrity sha512-feYHG+8McStfQ+mvFJTlmD1GQaYWiVlMf/Rv1MSRcd6UBBj+X8yj5OySw/Xau5PYFPCms7FbpCkt6437iRW47w==
+  dependencies:
+    focus-options-polyfill "1.2.0"
+    react-use "^17.2.1"
+    tslib "^2.1.0"
+
 react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"
@@ -15537,7 +15551,7 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use@^17.3.2:
+react-use@^17.2.1, react-use@^17.3.2:
   version "17.3.2"
   resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.3.2.tgz#448abf515f47c41c32455024db28167cb6e53be8"
   integrity sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==


### PR DESCRIPTION
### What is included? 
This PR adds the `react-image-medium-zoom` to provide a lightbox for the images in the blog posts and also in the Image component.

### How to verify:
- click on some images on https://satellytescommain21751-feataddmediumzoom.gtsb.io/blog/we-work-remotely/
- or https://satellytescommain21751-feataddmediumzoom.gtsb.io/about-us/

### Question:
On large screens (or when the images are really small, like the team images), the image is not sharp in the zoomed state, how do we want do deal with that?