### PR TITLE
feat(blog): append footnotes after rich text

### DIFF
--- a/src/components/layout/use-anchor-tag-scrolling.ts
+++ b/src/components/layout/use-anchor-tag-scrolling.ts
@@ -7,18 +7,25 @@ export const useAnchorTagScrolling = (): void => {
       const target = document.querySelector(
         `a[href*='${window.location.hash}']`,
       );
-      if (target) {
-        const scrollTop =
-          target.getBoundingClientRect().top +
-          window.pageYOffset -
-          // we need to scroll past the header and a little offset
-          (Number.parseInt(HEADER_HEIGHT, 10) + 16);
-
-        window.scrollTo({
-          top: scrollTop,
-          behavior: 'smooth',
-        });
-      }
+      scrollToTarget(target);
     }
   }, []);
+};
+
+export const scrollToTarget = (target: Element | null) => {
+  if (!target) {
+    console.error(`Expected Element, but got: ${target}`);
+    return;
+  }
+
+  const scrollTop =
+    target.getBoundingClientRect().top +
+    window.pageYOffset -
+    // we need to scroll past the header and a little offset
+    (Number.parseInt(HEADER_HEIGHT, 10) + 16);
+
+  window.scrollTo({
+    top: scrollTop,
+    behavior: 'smooth',
+  });
 };

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -73,12 +73,10 @@ const customContentfulRenderer = (
   /**
    * Filter out footnotes from content references
    */
-  const footnotes: ContentfulFootnoteReference[] = data.references
-    .filter(
-      (reference) =>
-        reference.__typename === ContentfulCustomModel.CONTENTFUL_FOOTNOTE,
-    )
-    .map((reference) => reference as ContentfulFootnoteReference);
+  const footnotes: ContentfulFootnoteReference[] = data.references.filter(
+    (reference) =>
+      reference.__typename === ContentfulCustomModel.CONTENTFUL_FOOTNOTE,
+  ) as ContentfulFootnoteReference[];
 
   /**
    * Create an object that contains information we'll use later

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -284,7 +284,12 @@ const customContentfulRenderer = (
   return (
     <div>
       {renderRichText(data, contentfulRenderOptions)}
-      {footNoteElements}
+      {footnotes.length > 0 && (
+        <>
+          <hr />
+          {footNoteElements}
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -35,6 +35,11 @@ enum ContentfulCustomModel {
   CONTENTFUL_CODE_BLOCK = 'ContentfulCodeBlock',
   CONTENTFUL_BLOG_POST_COLLAPSIBLE = 'ContentfulBlogPostCollapsible',
 }
+
+enum EmbeddedAssetType {
+  IMAGE = 'image',
+  VIDEO = 'video',
+}
 interface FootnoteReference {
   [key: string]: {
     index: number;
@@ -194,7 +199,10 @@ const customContentfulRenderer = (
       [BLOCKS.EMBEDDED_ASSET]: (node) => {
         const { contentType, url } = node.data.target.file;
         switch (contentType.split('/')[0]) {
-          case 'image': {
+          /**
+           * Embedded images
+           */
+          case EmbeddedAssetType.IMAGE: {
             return customComponents.figure({
               children: [
                 <Zoom key={node.data.target.file.url}>
@@ -210,7 +218,10 @@ const customContentfulRenderer = (
               ],
             });
           }
-          case 'video': {
+          /**
+           * Embedded videos
+           */
+          case EmbeddedAssetType.VIDEO: {
             return customComponents.figure({
               children: [
                 <video

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -2,8 +2,12 @@ import { Options } from '@contentful/rich-text-react-renderer';
 import { BLOCKS, INLINES, MARKS } from '@contentful/rich-text-types';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { renderRichText } from 'gatsby-source-contentful/rich-text';
-import React from 'react';
+import {
+  ContentfulRichTextGatsbyReference,
+  renderRichText,
+  RenderRichTextData,
+} from 'gatsby-source-contentful/rich-text';
+import React, { MouseEvent } from 'react';
 import styled from 'styled-components';
 import { BlogArticleQueryData } from '../../../templates/blog-post';
 import { BreadcrumbEntry } from '../../../types';
@@ -12,6 +16,7 @@ import { BlogHero } from '../../content/heroes/blog-hero';
 import { LeadboxProps } from '../../content/leadbox/leadbox';
 import { LONG_DATE_FORMAT, useLocaleFormat } from '../../i18n-helpers';
 import { Layout } from '../../layout/layout';
+import { scrollToTarget } from '../../layout/use-anchor-tag-scrolling';
 import customComponents from '../../legacy/markdown/custom-components';
 import { MarkdownAst } from '../../legacy/markdown/markdown-ast';
 import { up } from '../../support/breakpoint';
@@ -19,6 +24,24 @@ import FollowPanel from './follow-panel';
 import SharePanel from './share-panel';
 import Zoom from 'react-medium-image-zoom';
 import 'react-medium-image-zoom/dist/styles.css';
+
+interface ContentfulFootnoteReference
+  extends ContentfulRichTextGatsbyReference {
+  note: any; // TODO: Improve typing here
+}
+
+enum ContentfulCustomModel {
+  CONTENTFUL_FOOTNOTE = 'ContentfulFootnote',
+  CONTENTFUL_CODE_BLOCK = 'ContentfulCodeBlock',
+  CONTENTFUL_BLOG_POST_COLLAPSIBLE = 'ContentfulBlogPostCollapsible',
+}
+interface FootnoteReference {
+  [key: string]: {
+    index: number;
+    anchor: string;
+    referenceAnchor: string;
+  };
+}
 
 interface BlogPostPageProps {
   blogPost: BlogArticleQueryData;
@@ -35,108 +58,235 @@ const PanelContainer = styled.div`
   }
 `;
 
-const contentfulRenderOptions: Options = {
-  renderMark: {
-    [MARKS.CODE]: (text) => <code className="language-text">{text}</code>,
-  },
-  renderNode: {
-    [INLINES.HYPERLINK]: (props, children) =>
-      customComponents.a({
-        children,
-        href: props.data.uri,
-        target: '_blank',
-        rel: 'nofollow noopener noreferrer',
+/**
+ * Custom Contentful Rich Text Renderer
+ *
+ * Will automatically filter out ContentfulFootnote elements and appends an
+ * ordered list of footnotes after the rendered rich text.
+ *
+ * @param data rich text data
+ * @returns rendered elements
+ */
+const customContentfulRenderer = (
+  data: RenderRichTextData<ContentfulRichTextGatsbyReference>,
+) => {
+  /**
+   * Filter out footnotes from content references
+   */
+  const footnotes: ContentfulFootnoteReference[] = data.references
+    .filter(
+      (reference) =>
+        reference.__typename === ContentfulCustomModel.CONTENTFUL_FOOTNOTE,
+    )
+    .map((reference) => reference as ContentfulFootnoteReference);
+
+  /**
+   * Create an object that contains information we'll use later
+   */
+  const footnoteReferences: FootnoteReference = {};
+  footnotes.map(
+    (footnote, index) =>
+      (footnoteReferences[footnote.contentful_id] = {
+        index: index + 1,
+        anchor: `footnote-${index + 1}`,
+        referenceAnchor: `footnote-${index + 1}-reference`,
       }),
-    [BLOCKS.HEADING_1]: (props, children) => customComponents.h1({ children }),
-    [BLOCKS.HEADING_2]: (props, children) => customComponents.h2({ children }),
-    [BLOCKS.HEADING_3]: (props, children) => customComponents.h3({ children }),
-    [BLOCKS.HEADING_4]: (props, children) => customComponents.h4({ children }),
-    [BLOCKS.HEADING_5]: (props, children) => customComponents.h5({ children }),
-    [BLOCKS.HEADING_6]: (props, children) => customComponents.h6({ children }),
-    [BLOCKS.HEADING_6]: (props, children) => customComponents.h6({ children }),
-    [BLOCKS.OL_LIST]: (props, children) => customComponents.ol({ children }),
-    [BLOCKS.UL_LIST]: (props, children) => customComponents.ul({ children }),
-    [BLOCKS.QUOTE]: (props, children) =>
-      customComponents.blockquote({ children }),
-    [BLOCKS.PARAGRAPH]: (props, children) => customComponents.p({ children }),
-    [BLOCKS.EMBEDDED_ENTRY]: (node) => {
-      const { __typename } = node.data.target;
-      switch (__typename) {
-        /**
-         * Code Blocks
-         */
-        case 'ContentfulCodeBlock': {
-          const { code } = node.data.target;
-          return <MarkdownAst htmlAst={code.childMarkdownRemark.htmlAst} />;
-        }
-        /**
-         * Blog Post Collapsible
-         */
-        case 'ContentfulBlogPostCollapsible': {
-          const { content, summary } = node.data.target;
-          return customComponents.details({
-            children: [
-              <summary key="summary">{summary}</summary>,
-              renderRichText(content, contentfulRenderOptions),
-            ],
-          });
-        }
-        /**
-         * Log error to console if type is not yet implemented
-         */
-        default:
-          console.error(
-            `Embedded entry type is not implemented: ${__typename}`,
-          );
-          return null;
-      }
+  );
+
+  /**
+   * The options object used by the Contentful Rich Text Renderer
+   */
+  const contentfulRenderOptions: Options = {
+    renderMark: {
+      [MARKS.CODE]: (text) => <code className="language-text">{text}</code>,
     },
-    [BLOCKS.EMBEDDED_ASSET]: (node) => {
-      const { contentType, url } = node.data.target.file;
-      switch (contentType.split('/')[0]) {
-        case 'image': {
-          return customComponents.figure({
-            children: [
-              <Zoom key={node.data.target.file.url}>
-                <GatsbyImage
-                  image={node.data.target.gatsbyImageData}
-                  alt={node.data.target.description}
-                />
-              </Zoom>,
-              customComponents.figcaption({
-                key: 'figcaption',
-                children: node.data.target.description,
-              }),
-            ],
-          });
+    renderNode: {
+      [INLINES.HYPERLINK]: (props, children) =>
+        customComponents.a({
+          children,
+          href: props.data.uri,
+          target: '_blank',
+          rel: 'nofollow noopener noreferrer',
+        }),
+      [INLINES.EMBEDDED_ENTRY]: (node) => {
+        const { __typename } = node.data.target;
+        switch (__typename) {
+          /**
+           * Footnote
+           */
+          case ContentfulCustomModel.CONTENTFUL_FOOTNOTE: {
+            const { contentful_id, content } = node.data.target;
+            const reference = footnoteReferences[contentful_id];
+
+            return (
+              <>
+                <mark>{content.content}</mark>
+                {customComponents.a({
+                  id: reference.referenceAnchor,
+                  children: <sup>{reference?.index}</sup>,
+                  href: `#${reference?.anchor}`,
+                  onClick: (e: MouseEvent) => {
+                    e.preventDefault();
+                    const target = document.querySelector(
+                      `[id='${reference?.anchor}']`,
+                    );
+                    history.pushState({}, '', `#${reference?.anchor}`);
+                    scrollToTarget(target);
+                  },
+                })}
+              </>
+            );
+          }
+          /**
+           * Log error to console if type is not yet implemented
+           */
+          default:
+            console.error(
+              `Embedded entry type is not implemented: ${__typename}`,
+            );
+            return null;
         }
-        case 'video': {
-          return customComponents.figure({
-            children: [
-              <video
-                key="video"
-                preload="auto"
-                autoPlay
-                loop
-                muted
-                width="100%"
-              >
-                <source src={url} type={contentType} />
-              </video>,
-              customComponents.figcaption({
-                key: 'figcaption',
-                children: node.data.target.description,
-              }),
-            ],
-          });
+      },
+      [BLOCKS.HEADING_1]: (props, children) =>
+        customComponents.h1({ children }),
+      [BLOCKS.HEADING_2]: (props, children) =>
+        customComponents.h2({ children }),
+      [BLOCKS.HEADING_3]: (props, children) =>
+        customComponents.h3({ children }),
+      [BLOCKS.HEADING_4]: (props, children) =>
+        customComponents.h4({ children }),
+      [BLOCKS.HEADING_5]: (props, children) =>
+        customComponents.h5({ children }),
+      [BLOCKS.HEADING_6]: (props, children) =>
+        customComponents.h6({ children }),
+      [BLOCKS.HEADING_6]: (props, children) =>
+        customComponents.h6({ children }),
+      [BLOCKS.OL_LIST]: (props, children) => customComponents.ol({ children }),
+      [BLOCKS.UL_LIST]: (props, children) => customComponents.ul({ children }),
+      [BLOCKS.QUOTE]: (props, children) =>
+        customComponents.blockquote({ children }),
+      [BLOCKS.PARAGRAPH]: (props, children) => customComponents.p({ children }),
+      [BLOCKS.EMBEDDED_ENTRY]: (node) => {
+        const { __typename } = node.data.target;
+        switch (__typename) {
+          /**
+           * Code Blocks
+           */
+          case ContentfulCustomModel.CONTENTFUL_CODE_BLOCK: {
+            const { code } = node.data.target;
+            return <MarkdownAst htmlAst={code.childMarkdownRemark.htmlAst} />;
+          }
+          /**
+           * Blog Post Collapsible
+           */
+          case ContentfulCustomModel.CONTENTFUL_BLOG_POST_COLLAPSIBLE: {
+            const { content, summary } = node.data.target;
+            return customComponents.details({
+              children: [
+                <summary key="summary">{summary}</summary>,
+                renderRichText(content, contentfulRenderOptions),
+              ],
+            });
+          }
+          /**
+           * Log error to console if type is not yet implemented
+           */
+          default:
+            console.error(
+              `Embedded entry type is not implemented: ${__typename}`,
+            );
+            return null;
         }
-        default: {
-          console.error(`Content type is not implemented: ${contentType}`);
-          return null;
+      },
+      [BLOCKS.EMBEDDED_ASSET]: (node) => {
+        const { contentType, url } = node.data.target.file;
+        switch (contentType.split('/')[0]) {
+          case 'image': {
+            return customComponents.figure({
+              children: [
+                <Zoom key={node.data.target.file.url}>
+                  <GatsbyImage
+                    image={node.data.target.gatsbyImageData}
+                    alt={node.data.target.description}
+                  />
+                </Zoom>,
+                customComponents.figcaption({
+                  key: 'figcaption',
+                  children: node.data.target.description,
+                }),
+              ],
+            });
+          }
+          case 'video': {
+            return customComponents.figure({
+              children: [
+                <video
+                  key="video"
+                  preload="auto"
+                  autoPlay
+                  loop
+                  muted
+                  width="100%"
+                >
+                  <source src={url} type={contentType} />
+                </video>,
+                customComponents.figcaption({
+                  key: 'figcaption',
+                  children: node.data.target.description,
+                }),
+              ],
+            });
+          }
+          default: {
+            console.error(`Content type is not implemented: ${contentType}`);
+            return null;
+          }
         }
-      }
+      },
     },
-  },
+  };
+
+  /**
+   * Footnote elements
+   */
+  const footNoteElements = customComponents.ol({
+    children: footnotes.map((footnote) => {
+      const { contentful_id, note } = footnote;
+      const { anchor, referenceAnchor } = footnoteReferences[contentful_id];
+      return (
+        <li key={contentful_id} id={anchor}>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <MarkdownAst
+              key={contentful_id}
+              htmlAst={note.childMarkdownRemark.htmlAst}
+            />
+            {customComponents.a({
+              children: '\u21A9',
+              href: `#${referenceAnchor}`,
+              onClick: (e: MouseEvent) => {
+                e.preventDefault();
+                const target = document.querySelector(
+                  `[id='${referenceAnchor}']`,
+                );
+                history.pushState({}, '', `#${referenceAnchor}`);
+                scrollToTarget(target);
+              },
+            })}
+          </div>
+        </li>
+      );
+    }),
+  });
+
+  /**
+   * Rendered Rich Text + Footnotes
+   */
+  return (
+    <div>
+      {renderRichText(data, contentfulRenderOptions)}
+      {footNoteElements}
+    </div>
+  );
 };
 
 export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
@@ -176,7 +326,7 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
       breadcrumb={breadcrumb}
     >
       <BlogHeader headline={blogPost.title} byline={heroByLine} />
-      <div>{renderRichText(blogPost.content, contentfulRenderOptions)}</div>
+      {customContentfulRenderer(blogPost.content)}
 
       <PanelContainer>
         <SharePanel title={blogPost.title} />

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -113,27 +113,22 @@ const customContentfulRenderer = (
            * Footnote
            */
           case ContentfulCustomModel.CONTENTFUL_FOOTNOTE: {
-            const { contentful_id, content } = node.data.target;
+            const { contentful_id } = node.data.target;
             const reference = footnoteReferences[contentful_id];
 
-            return (
-              <>
-                {content?.content && <mark>{content.content}</mark>}
-                {customComponents.a({
-                  id: reference.referenceAnchor,
-                  children: <sup>{reference?.index}</sup>,
-                  href: `#${reference?.anchor}`,
-                  onClick: (e: MouseEvent) => {
-                    e.preventDefault();
-                    const target = document.querySelector(
-                      `[id='${reference?.anchor}']`,
-                    );
-                    history.pushState({}, '', `#${reference?.anchor}`);
-                    scrollToTarget(target);
-                  },
-                })}
-              </>
-            );
+            return customComponents.a({
+              id: reference.referenceAnchor,
+              children: <sup>{reference?.index}</sup>,
+              href: `#${reference?.anchor}`,
+              onClick: (e: MouseEvent) => {
+                e.preventDefault();
+                const target = document.querySelector(
+                  `[id='${reference?.anchor}']`,
+                );
+                history.pushState({}, '', `#${reference?.anchor}`);
+                scrollToTarget(target);
+              },
+            });
           }
           /**
            * Log error to console if type is not yet implemented

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -120,7 +120,7 @@ const customContentfulRenderer = (
 
             return (
               <>
-                <mark>{content.content}</mark>
+                {content?.content && <mark>{content.content}</mark>}
                 {customComponents.a({
                   id: reference.referenceAnchor,
                   children: <sup>{reference?.index}</sup>,

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -101,6 +101,19 @@ export const BlogPostPageQuery = graphql`
             __typename
           }
 
+          ... on ContentfulFootnote {
+            contentful_id
+            __typename
+            content {
+              content
+            }
+            note {
+              childMarkdownRemark {
+                htmlAst
+              }
+            }
+          }
+
           ... on ContentfulBlogPostCollapsible {
             contentful_id
             __typename

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -104,9 +104,6 @@ export const BlogPostPageQuery = graphql`
           ... on ContentfulFootnote {
             contentful_id
             __typename
-            content {
-              content
-            }
             note {
               childMarkdownRemark {
                 htmlAst


### PR DESCRIPTION
This PR enables us to place footnotes in rich texts.

## What's changing?

When footnotes are placed inside rich text, the nodes are filtered out and then rendered separately below the content.
There will be a link to the footnote below the content created. The footnote itself contains a link back to its reference.

## How is this implemented?

### Our **Footnote Content Model**
<img width="941" alt="Bildschirmfoto 2022-04-01 um 09 47 50" src="https://user-images.githubusercontent.com/3493187/161219331-0bdf3fce-efab-47d6-9f0f-46039f28a98e.png">


- The `content` field is optional and can contain text that gets highlighted
- The `note` field contains the actual footnote information

### How it looks when placed inside the rich text field
<img width="812" alt="Bildschirmfoto 2022-04-01 um 09 48 59" src="https://user-images.githubusercontent.com/3493187/161219356-79d44449-04df-4dc2-a114-6b1807849fb9.png">

Footnotes are placed as inline entities inside a rich text field.

### Editing a footnote
<img width="806" alt="Bildschirmfoto 2022-04-01 um 09 49 11" src="https://user-images.githubusercontent.com/3493187/161219428-bb657336-af8e-4cfd-a57d-96ca8e5f1967.png">
The fields have a hint text to help the author.


### The rendered content
<img width="857" alt="Bildschirmfoto 2022-04-01 um 09 49 29" src="https://user-images.githubusercontent.com/3493187/161219472-4490e642-7d1c-48b2-8ffb-5b85a45b5d5a.png">
Here is how the rendered content looks like. When footnotes exist, the list as well as a `hr` is appended below the content.

## Good to know
The GraphQL query is failing in the Gatsby Cloud because the content is not published yet.
Background: The Contentful plugin will only generate classes for content models that contain data. Since there is no data yet (not published), the entity is skipped which is causing the error.

We need to publish at least one article which contains a `ContentfulFootnote` before the Gatsby Cloud build can succeed.
