### PR TITLE
build(github): build storybook if `deploy-storybook` label exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,9 @@ jobs:
         run: yarn build
 
   build-storybook:
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'dependencies') 
+      || contains(github.event.pull_request.labels.*.name, 'deploy-storybook')
     name: Build Storybook
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,32 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build
         run: yarn storybook:build
+  
+  publish-storybook:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy-storybook')
+    name: Publish Storybook on Netlify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn' 
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      
+      - name: Build
+        run: yarn storybook:build 
+
+      - name: Deploy draft to Netlify
+        uses: South-Paw/action-netlify-deploy@v1.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
+          build-dir: './storybook-static'
+          draft: true
+          comment-on-pull-request: true


### PR DESCRIPTION
## What is changing?
A new condition for the `build-storybook` job is introduced.
The job will now run if either a `dependencies` or `deploy-storybook` label exists.

## How to test?
I've used [act](https://github.com/nektos/act) to test this locally. 

```bash
act pull_request -e pull_request.json
```

**pull_request.json**
```json
{
  "pull_request": {
    "labels": [
      {
        "name": "deploy-storybook"
      }
    ]
  },
  "head": {
    "ref": "sample-head-ref"
  },
  "base": {
    "ref": "sample-base-ref"
  }
}
```

## ToDos
- [x] Disable automatic Netlify build
- [x] Manually trigger Netlify build