### PR TITLE
build(github): set contentful variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
+        env:
+          CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
 
   build-storybook:
     if: |


### PR DESCRIPTION
Our dependabot build fail currently because the environment variables are not set before building the website.

## What's changing?
I've already set the missing variables in the [Actions secrets](https://github.com/satellytes/satellytes.com/settings/secrets/actions). This change will use them during the build.