### PR TITLE
feat/improve header order

### DIFF
--- a/src/components/content/header-block/header-block.tsx
+++ b/src/components/content/header-block/header-block.tsx
@@ -46,7 +46,7 @@ const Topline = styled.p`
   margin: 0;
 `;
 
-const Headline = styled.p<LargeProps>`
+const Headline = styled.h2<LargeProps>`
   ${TextStyles.headlineL}
   letter-spacing: -0.01em;
   color: #202840;

--- a/src/components/content/section-header/section-header.tsx
+++ b/src/components/content/section-header/section-header.tsx
@@ -9,6 +9,11 @@ interface SectionHeaderProps {
    */
   kicker?: string;
   /**
+   * html tag as which the kicker will be rendered
+   * @default "span"
+   */
+  kickerAs?: any;
+  /**
    * The headline for the given section
    */
   headline: string;
@@ -54,7 +59,9 @@ const ContentStyled = styled.div`
 export const SectionHeader = (props: SectionHeaderProps) => {
   return (
     <div className={props.className}>
-      {props.kicker && <KickerStyled>{props.kicker}</KickerStyled>}
+      {props.kicker && (
+        <KickerStyled as={props.kickerAs}>{props.kicker}</KickerStyled>
+      )}
       <HeadlineStyled as={props.as}>{props.headline}</HeadlineStyled>
       <ContentStyled>{props.children}</ContentStyled>
     </div>

--- a/src/components/content/section-header/section-header.tsx
+++ b/src/components/content/section-header/section-header.tsx
@@ -14,6 +14,7 @@ interface SectionHeaderProps {
   headline: string;
   /**
    * html tag as which the headline will be rendered
+   * @default "h2"
    */
   as?: any;
   /**

--- a/src/components/content/section-header/section-header.tsx
+++ b/src/components/content/section-header/section-header.tsx
@@ -13,6 +13,10 @@ interface SectionHeaderProps {
    */
   headline: string;
   /**
+   * html tag as which the headline will be rendered
+   */
+  as?: any;
+  /**
    * The actual text content
    */
   children?: React.ReactNode;
@@ -50,7 +54,7 @@ export const SectionHeader = (props: SectionHeaderProps) => {
   return (
     <div className={props.className}>
       {props.kicker && <KickerStyled>{props.kicker}</KickerStyled>}
-      <HeadlineStyled>{props.headline}</HeadlineStyled>
+      <HeadlineStyled as={props.as}>{props.headline}</HeadlineStyled>
       <ContentStyled>{props.children}</ContentStyled>
     </div>
   );

--- a/src/components/content/teaser/teaser.tsx
+++ b/src/components/content/teaser/teaser.tsx
@@ -65,7 +65,7 @@ const TeaserText = styled.div`
   margin: 0;
 `;
 
-const StyledTeaserTitle = styled.p<{
+const StyledTeaserTitle = styled.h3<{
   large: boolean;
   hasTopline: boolean;
 }>`

--- a/src/components/content/teaser/teaser.tsx
+++ b/src/components/content/teaser/teaser.tsx
@@ -90,6 +90,11 @@ export interface TeaserProps {
    */
   title: string;
   /**
+   * html tag, as which the teaser title will be rendered
+   * @default "h3"
+   */
+  as?: any;
+  /**
    * A topline/kicker which can be added
    */
   topline?: string;
@@ -139,6 +144,7 @@ export const Teaser = ({
   topline,
   language,
   title,
+  as,
   dateFormatted,
   image,
   linkTo,
@@ -175,6 +181,7 @@ export const Teaser = ({
           </ToplineContainer>
         )}
         <StyledTeaserTitle
+          as={as}
           large={!(image || illustration)}
           hasTopline={hasToplineContainer}
         >

--- a/src/components/pages/blog/blog-page.tsx
+++ b/src/components/pages/blog/blog-page.tsx
@@ -28,7 +28,7 @@ export const BlogPage = ({ posts }: BlogPageProps) => {
   return (
     <Layout light showLanguageSwitch={false} breadcrumb={BREADCRUMB}>
       <ContentBlockContainer>
-        <BlogHeader headline={t('navigation.blog')}>
+        <BlogHeader forwardedAs={'h1'} headline={t('navigation.blog')}>
           {t('blog.info')}
 
           {language != 'en' && <NotAvailableInGerman />}

--- a/src/components/pages/blog/posts.tsx
+++ b/src/components/pages/blog/posts.tsx
@@ -29,6 +29,7 @@ export const Posts = ({ posts }: PostsProps) => {
 
         return (
           <Teaser
+            as={'h2'}
             key={item.id}
             title={item.title}
             linkTo={item.fields.path}

--- a/src/components/pages/career-details/career-details.tsx
+++ b/src/components/pages/career-details/career-details.tsx
@@ -58,7 +58,11 @@ export const CareerDetails = ({
       showLanguageSwitch={Boolean(complementPath)}
     >
       <ContentBlockContainer>
-        <SectionHeader headline={position.name} kicker={t('career.position')}>
+        <SectionHeader
+          as={'h1'}
+          headline={position.name}
+          kicker={t('career.position')}
+        >
           {position.short}
         </SectionHeader>
       </ContentBlockContainer>

--- a/src/components/pages/career-details/job-description.tsx
+++ b/src/components/pages/career-details/job-description.tsx
@@ -53,7 +53,7 @@ export const JobDescription = ({ sections }: JobDescriptionProps) => {
       {sections?.map(({ headline, descriptionHtml }, index) => {
         return (
           <div key={index}>
-            <SectionHeadline as={'h2'}>{headline}</SectionHeadline>
+            <SectionHeadline>{headline}</SectionHeadline>
             <PersonioHtml
               dangerouslySetInnerHTML={{ __html: descriptionHtml }}
             />

--- a/src/components/pages/career-details/job-description.tsx
+++ b/src/components/pages/career-details/job-description.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TextTitle } from '../../legacy/typography';
 import { up } from '../../support/breakpoint';
 import { SyPersonioJobSection } from '../../../types';
+import { TextStyles } from '../../typography';
 
-export const SectionHeadline = styled(TextTitle)`
+export const SectionHeadline = styled.h2`
+  ${TextStyles.headlineM}
+
   margin-top: 40px;
   margin-bottom: 16px;
 
@@ -51,7 +53,7 @@ export const JobDescription = ({ sections }: JobDescriptionProps) => {
       {sections?.map(({ headline, descriptionHtml }, index) => {
         return (
           <div key={index}>
-            <SectionHeadline>{headline}</SectionHeadline>
+            <SectionHeadline as={'h2'}>{headline}</SectionHeadline>
             <PersonioHtml
               dangerouslySetInnerHTML={{ __html: descriptionHtml }}
             />

--- a/src/components/pages/career/career-page.tsx
+++ b/src/components/pages/career/career-page.tsx
@@ -39,6 +39,7 @@ export const CareerPage = ({ positions, heroImageData }: CareerPageProps) => {
     >
       <ContentBlockContainer>
         <SectionHeader
+          as={'h1'}
           kicker={t('career.introduction.kicker')}
           headline={t('career.introduction.headline')}
         >

--- a/src/components/pages/contact/address.tsx
+++ b/src/components/pages/contact/address.tsx
@@ -17,7 +17,11 @@ export const Address = () => {
   const { t } = useTranslation();
 
   return (
-    <SectionHeader headline={t('contact.address')} kicker={t('contact.title')}>
+    <SectionHeader
+      headline={t('contact.address')}
+      kicker={t('contact.title')}
+      kickerAs={'h1'}
+    >
       Satellytes Digital Consulting GmbH
       <br />
       Sendlinger Straße 52

--- a/src/components/pages/service/industries.tsx
+++ b/src/components/pages/service/industries.tsx
@@ -12,7 +12,7 @@ interface IndustriesProps {
   className?: string;
 }
 
-const HeadlineStyled = styled.h3`
+const HeadlineStyled = styled.h2`
   ${TextStyles.headlineL}
   margin: 0;
   color: #202840;
@@ -31,16 +31,6 @@ const ContentStyled = styled.div`
     ${TextStyles.textL}
   }
 `;
-
-export const Intro = ({ illustration, headline, children }: any) => (
-  <IntroLayout>
-    <IllustrationStyled size={IllustrationSize.LARGE} show={illustration} />
-    <div>
-      <HeadlineStyled>{headline}</HeadlineStyled>
-      <ContentStyled>{children}</ContentStyled>
-    </div>
-  </IntroLayout>
-);
 
 const TeaserContainer = styled.div`
   display: grid;

--- a/src/pages/data-privacy.tsx
+++ b/src/pages/data-privacy.tsx
@@ -27,7 +27,7 @@ const DataPrivacyPage = ({
         noIndex={true}
       />
       <ContentBlockContainer>
-        <SectionHeader headline={t('navigation.data-privacy')} />
+        <SectionHeader as={'h1'} headline={t('navigation.data-privacy')} />
         <MarkdownAst htmlAst={data.markdownRemark.htmlAst} />
       </ContentBlockContainer>
     </Layout>

--- a/src/pages/imprint.tsx
+++ b/src/pages/imprint.tsx
@@ -31,7 +31,7 @@ const ImprintPage = ({ data, location }: PageProps<ImprintPageQueryProps>) => {
         noIndex={true}
       />
       <ContentBlockContainer>
-        <SectionHeader headline={t('navigation.imprint')} />
+        <SectionHeader as={'h1'} headline={t('navigation.imprint')} />
         <MarkdownAst htmlAst={data.markdownRemark.htmlAst} />
         <BottomNote>{t('imprint.updated')}</BottomNote>
       </ContentBlockContainer>


### PR DESCRIPTION
### What is included?

This PR makes some smaller changes to improve the header structure of our pages.

### Some inconsistencies
There are some pages where I was not sure how to achieve a correct structure

#### Contact Page
- I would suggest to change the "Email" headline to "Contact us" and put it as h1 on top of the page
- Shall Address be then a h2 ? Or shall we add a new h1 and render "contact us" and "address" as h2?

#### Markdown Pages (Imprint and Data Privacy)
- The section headlines are currently "####" in markdown -> h4
- But for correct header structure they should be h2s
- Shall I change it to "##"? But it looks a little bit weird since they are so large then

![image](https://user-images.githubusercontent.com/78978542/161720179-309f5de7-782c-44b0-ad4b-78ff578bfbe6.png)


closese #548 