### PR TITLE
Chore: remove legacy typography

### DIFF
--- a/src/components/legacy/typography.tsx
+++ b/src/components/legacy/typography.tsx
@@ -1,56 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { up } from '../support/breakpoint';
 import { theme } from '../layout/theme';
-import { Swoosh } from './icons/header-icons/swoosh';
-import { HEADER_HEIGHT } from '../layout/header/header';
 import { Link } from './links/links';
-
-const TitleContainer = styled.div`
-  margin-top: calc(96px + ${HEADER_HEIGHT});
-  margin-bottom: 40px;
-
-  ${up('md')} {
-    margin-top: calc(160px + ${HEADER_HEIGHT});
-  }
-`;
-
-export const PageTitleSwoosh = styled(Swoosh)`
-  position: absolute;
-  left: 3px;
-
-  top: -8px;
-  height: 10px;
-  width: 33px;
-
-  ${up('md')} {
-    width: 49px;
-    top: -16px;
-    height: 15px;
-  }
-`;
-
-export const StyledTitle = styled.h1`
-  position: relative;
-  font-size: 48px;
-  line-height: 110%;
-  margin: 0;
-
-  ${up('md')} {
-    font-size: 72px;
-  }
-`;
-
-export const PageTitle = (props) => {
-  return (
-    <TitleContainer className={props.className}>
-      <StyledTitle>
-        <PageTitleSwoosh />
-        {props.children}
-      </StyledTitle>
-    </TitleContainer>
-  );
-};
 
 export const SubTitle = styled.h3`
   font-size: 36px;
@@ -90,41 +41,4 @@ export const Text = styled.p`
   margin-bottom: 16px;
 
   white-space: pre-wrap;
-`;
-
-export const CaptionText = styled.p`
-  font-size: 12px;
-  line-height: 110%;
-  font-weight: bold;
-
-  color: #668cff;
-`;
-
-export const Topline = styled.p`
-  font-weight: bold;
-  font-size: 16px;
-  line-height: 110%;
-  margin: 0;
-
-  color: ${theme.palette.text.topline};
-`;
-
-export const ImageCardSubtitle = styled.p`
-  font-size: 14px;
-  line-height: 150%;
-`;
-
-export const TextLink = styled(Link)<{ small?: boolean }>`
-  display: inline-block;
-  color: ${theme.palette.text.link.default};
-
-  font-size: ${(props) => (props.small ? '14px' : '16px')};
-  line-height: 150%;
-  font-weight: bold;
-  text-decoration: none;
-
-  &:hover {
-    color: ${theme.palette.text.link.hover};
-    text-decoration: underline;
-  }
 `;

--- a/src/components/legacy/typography.tsx
+++ b/src/components/legacy/typography.tsx
@@ -1,7 +1,4 @@
-import React from 'react';
 import styled from 'styled-components';
-import { theme } from '../layout/theme';
-import { Link } from './links/links';
 
 export const SubTitle = styled.h3`
   font-size: 36px;

--- a/src/components/pages/career-details/job-description.tsx
+++ b/src/components/pages/career-details/job-description.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TextTitle } from '../../legacy/typography';
 import { up } from '../../support/breakpoint';
 import { SyPersonioJobSection } from '../../../types';
+import { TextStyles } from '../../typography';
 
-export const SectionHeadline = styled(TextTitle)`
+export const SectionHeadline = styled.h2`
+  ${TextStyles.headlineM}
+
   margin-top: 40px;
   margin-bottom: 16px;
 

--- a/src/pages/imprint.tsx
+++ b/src/pages/imprint.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 import SEO from '../components/layout/seo';
 import { graphql, PageProps } from 'gatsby';
 import styled from 'styled-components';
-import { Text } from '../components/legacy/typography';
 import { MarkdownAst } from '../components/legacy/markdown/markdown-ast';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { Layout } from '../components/layout/layout';
 import { SectionHeader } from '../components/content/section-header/section-header';
 import { ContentBlockContainer } from '../components/layout/content-block-container';
+import { TextStyles } from '../components/typography';
 
-const BottomNote = styled(Text)`
+const BottomNote = styled.p`
+  ${TextStyles.textR}
+
   margin-top: 80px;
+  margin-bottom: 16px;
   opacity: 0.8;
 `;
 


### PR DESCRIPTION
### What is included?

I tried to remove the legacy typography, but unfortunately they are still used in the markdown rendering.
That is way I have not removed the whole typography but only the unused elements