### PR TITLE
feat: cache fonts on the CDN

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -272,6 +272,11 @@ const gatsbyConfig: GatsbyConfig = {
     },
     {
       resolve: `gatsby-plugin-gatsby-cloud`,
+      options: {
+        headers: {
+          '/fonts/*': ['Cache-Control: public, max-age=31536000, immutable'],
+        },
+      },
     },
     {
       resolve: `gatsby-source-filesystem`,


### PR DESCRIPTION
# Problem
Our fonts are not served with a proper `Cache-Control` header. This lowers the page speed and lighthouse score.

<img width="738" alt="Screenshot 2022-04-12 at 07 47 40" src="https://user-images.githubusercontent.com/7814926/162889554-6a94adf5-64f2-484a-b1e8-07de6c5d7d5d.png">

# Solution
Caching headers can be set via the [Gatsby Cloud plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-gatsby-cloud/#headers). I added an "infinite" caching time, as the fonts won't change.

![Screenshot 2022-04-12 at 07 55 50](https://user-images.githubusercontent.com/7814926/162890559-c7b600b6-db24-4f56-ab4a-70349f36df47.png)