### PR TITLE
feat: add gesture handling to leaflet

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "html-entities": "^2.3.2",
     "i18next": "^21.6.16",
     "leaflet": "^1.8.0",
+    "leaflet-gesture-handling": "^1.2.2",
     "modern-normalize": "1.1.0",
     "polished": "^4.2.2",
     "prismjs": "^1.28.0",

--- a/src/components/pages/contact/leaflet/leaflet.tsx
+++ b/src/components/pages/contact/leaflet/leaflet.tsx
@@ -1,3 +1,10 @@
+import * as L from 'leaflet';
+import { LatLngExpression } from 'leaflet';
+import { GestureHandling } from 'leaflet-gesture-handling';
+import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
+import 'leaflet/dist/leaflet.css';
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
 import {
   CircleMarker,
   LayersControl,
@@ -7,19 +14,11 @@ import {
   useMap,
   ZoomControl,
 } from 'react-leaflet';
-import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { LatLngExpression } from 'leaflet';
+import { theme } from '../../../layout/theme';
 import { up } from '../../../support/breakpoint';
 import { BringMeHome } from './bring-home';
 import { SatellytesMarkerIcon } from './sy-marker';
-import { theme } from '../../../layout/theme';
-import { Helmet } from 'react-helmet';
-
-import 'leaflet/dist/leaflet.css';
-import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
-import * as L from 'leaflet';
-import { GestureHandling } from 'leaflet-gesture-handling';
 
 const MAP_VIEW_ZOOM = 14;
 

--- a/src/components/pages/contact/leaflet/leaflet.tsx
+++ b/src/components/pages/contact/leaflet/leaflet.tsx
@@ -4,17 +4,23 @@ import {
   MapContainer,
   Marker,
   TileLayer,
+  useMap,
   ZoomControl,
 } from 'react-leaflet';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { LatLngExpression } from 'leaflet';
 import { up } from '../../../support/breakpoint';
-
 import { BringMeHome } from './bring-home';
 import { SatellytesMarkerIcon } from './sy-marker';
 import { theme } from '../../../layout/theme';
 import { Helmet } from 'react-helmet';
+
+import 'leaflet/dist/leaflet.css';
+import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
+import * as L from 'leaflet';
+import { GestureHandling } from 'leaflet-gesture-handling';
+
 const MAP_VIEW_ZOOM = 14;
 
 const OFFICE_COORDINATES: LatLngExpression = [48.13479, 11.56839];
@@ -57,13 +63,23 @@ const MapWrapper = styled.div`
   position: relative;
 `;
 
+const EnableGestureHandling = () => {
+  /**
+   * leaflet-gesture-handling does not add gestureHandling to the types
+   * but map.gestureHandling exists and works
+   */
+  const map = useMap() as any;
+  map.gestureHandling.enable();
+  L.Map.addInitHook('addHandler', 'gestureHandling', GestureHandling);
+  return null;
+};
+
 export const Leaflet = () => {
   const [isBrowser, setIsBrowser] = useState(false);
 
   useEffect(() => {
     setIsBrowser(true);
   });
-
   // we don't want to render leaflet outside of the browser (SSR)
   if (!isBrowser) {
     return <MapPlaceholder />;
@@ -76,6 +92,9 @@ export const Leaflet = () => {
       zoom={MAP_VIEW_ZOOM}
       scrollWheelZoom={true}
     >
+      {/* Component with no content for the DOM, just to get access to useMap(), this has to be inside MapContainer */}
+      <EnableGestureHandling />
+
       {/*Introduce a LayerControl so we can offer multiple tile layers if people want to explore the city
       without the minimal skin (and if they are curious enough to find the layer toggle of course)*/}
       <LayersControl position="bottomright">
@@ -131,6 +150,12 @@ export const Leaflet = () => {
           rel="stylesheet"
           href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
         />
+        <link
+          rel="stylesheet"
+          href="//unpkg.com/leaflet-gesture-handling/dist/leaflet-gesture-handling.min.css"
+          type="text/css"
+        />
+        <script src="//unpkg.com/leaflet-gesture-handling"></script>
       </Helmet>
       {MapView}
     </MapWrapper>

--- a/src/components/pages/contact/leaflet/leaflet.tsx
+++ b/src/components/pages/contact/leaflet/leaflet.tsx
@@ -1,8 +1,6 @@
 import * as L from 'leaflet';
 import { LatLngExpression } from 'leaflet';
 import { GestureHandling } from 'leaflet-gesture-handling';
-import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
-import 'leaflet/dist/leaflet.css';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12439,6 +12439,11 @@ lazy-universal-dotenv@^3.0.1:
     dotenv "^8.0.0"
     dotenv-expand "^5.1.0"
 
+leaflet-gesture-handling@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/leaflet-gesture-handling/-/leaflet-gesture-handling-1.2.2.tgz#ea10afb94f2d477d77d47beb21e409ed327df07a"
+  integrity sha512-Blf5V4PoNphWkzL7Y1qge+Spkd4OCQ2atjwUNhMhLIcjKzPcBH++x/lwOinaR9jSqLWqJ6oKYO8d0XdTffy4hQ==
+
 leaflet@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.8.0.tgz#4615db4a22a304e8e692cae9270b983b38a2055e"


### PR DESCRIPTION
### What is included?

This adds `leaflet-gesture-handling` to our leaflet on the contact page. That way it is possible to:
- scroll down the page even when hovering over the map
- zoom the map when hovering with pressing command or ctrl during scrolling
- zoom with two fingers on touchpad or mobile

### Some thougths

My implementation feels a little bit ugly, since `leaflet-gesture-handling` does not provide types (casting to any needed). 
And I added component returning null just to get access to useMap(). I dont know if this way is still fine, but I did not know a better way.