### PR TITLE
fix: break long links and inline codes in blogs

### DIFF
--- a/src/assets/prism-themes/coy-with-shadows.scss
+++ b/src/assets/prism-themes/coy-with-shadows.scss
@@ -61,6 +61,7 @@ pre[class*="language-"] > code {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+  overflow-wrap: anywhere;
 }
 
 .token.comment,

--- a/src/assets/prism-themes/default.scss
+++ b/src/assets/prism-themes/default.scss
@@ -76,6 +76,7 @@ pre[class*="language-"].line-numbers .line-numbers-rows {
   padding: .1em;
   border-radius: .3em;
   white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .token.comment,

--- a/src/assets/prism-themes/prism-theme-nord.scss
+++ b/src/assets/prism-themes/prism-theme-nord.scss
@@ -52,6 +52,7 @@ pre[class*="language-"].line-numbers .line-numbers-rows {
     padding: .1em;
     border-radius: .3em;
     white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .token.comment,

--- a/src/components/legacy/markdown/custom-components.tsx
+++ b/src/components/legacy/markdown/custom-components.tsx
@@ -118,10 +118,6 @@ const Figure = styled.figure`
   }
 `;
 
-const StyledCode = styled.code`
-  overflow-wrap: anywhere !important;
-`;
-
 const Figcaption = styled.figcaption`
   ${TextStyles.textS};
   color: ${theme.palette.text.timestamp};
@@ -232,9 +228,6 @@ const customSatellytesComponents = {
   figcaption(props) {
     const { children, ...rest } = props;
     return <Figcaption {...rest}>{children}</Figcaption>;
-  },
-  code(props) {
-    return <StyledCode {...props}>{props.children}</StyledCode>;
   },
 };
 

--- a/src/components/legacy/markdown/custom-components.tsx
+++ b/src/components/legacy/markdown/custom-components.tsx
@@ -118,6 +118,10 @@ const Figure = styled.figure`
   }
 `;
 
+const StyledCode = styled.code`
+  overflow-wrap: anywhere !important;
+`;
+
 const Figcaption = styled.figcaption`
   ${TextStyles.textS};
   color: ${theme.palette.text.timestamp};
@@ -228,6 +232,9 @@ const customSatellytesComponents = {
   figcaption(props) {
     const { children, ...rest } = props;
     return <Figcaption {...rest}>{children}</Figcaption>;
+  },
+  code(props) {
+    return <StyledCode {...props}>{props.children}</StyledCode>;
   },
 };
 

--- a/src/components/legacy/markdown/custom-components.tsx
+++ b/src/components/legacy/markdown/custom-components.tsx
@@ -52,6 +52,7 @@ const MarkdownLink = styled(Link)`
   line-height: 150%;
   font-weight: bold;
   text-decoration: none;
+  overflow-wrap: anywhere;
 
   &:hover {
     color: ${theme.palette.text.link.hover};

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -101,8 +101,7 @@ const customContentfulRenderer = (
    */
   const contentfulRenderOptions: Options = {
     renderMark: {
-      [MARKS.CODE]: (text) =>
-        customComponents.code({ children: text, className: 'language-text' }),
+      [MARKS.CODE]: (text) => <code className="language-text">{text}</code>,
     },
     renderNode: {
       [INLINES.HYPERLINK]: (props, children) =>

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -101,7 +101,8 @@ const customContentfulRenderer = (
    */
   const contentfulRenderOptions: Options = {
     renderMark: {
-      [MARKS.CODE]: (text) => <code className="language-text">{text}</code>,
+      [MARKS.CODE]: (text) =>
+        customComponents.code({ children: text, className: 'language-text' }),
     },
     renderNode: {
       [INLINES.HYPERLINK]: (props, children) =>


### PR DESCRIPTION
### What is included?

This PR breaks links and inline codes in blog posts when overflowing, to prevent them from killing the layout on mobile.

closes #604 