### PR TITLE
feat: add introText Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ yarn storybook:serve
 ```
 
 A production build of Storybook gets be created for every pull request. You will get the link as pull request comment.
-For the `main` branch, the  build can be found here: https://satellytes-website-storybook.netlify.app
+For the `main` branch, the build can be found here: https://satellytes-website-storybook.netlify.app
 
 ## Writing a blog post
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ yarn storybook:build
 yarn storybook:serve
 ```
 
-A production build of Storybook gets be created for every pull request. You will get the link as pull request comment. 
-For the `main` branch, the build can be found here: https://satellytes-website-storybook.netlify.app
+A production build of Storybook gets be created for every pull request. You will get the link as pull request comment.
+For the `main` branch, the  build can be found here: https://satellytes-website-storybook.netlify.app
 
 ## Writing a blog post
 

--- a/src/components/content/blog-header/blog-header.tsx
+++ b/src/components/content/blog-header/blog-header.tsx
@@ -47,10 +47,11 @@ const BylineStyled = styled.span`
 `;
 
 const LeadStyled = styled.div`
-  ${TextStyles.textL}
+  ${TextStyles.textR}
   margin-top: 48px;
 
   ${up('md')} {
+    ${TextStyles.textL}
     margin-top: 32px;
   }
 `;

--- a/src/components/content/blog-header/blog-header.tsx
+++ b/src/components/content/blog-header/blog-header.tsx
@@ -47,12 +47,11 @@ const BylineStyled = styled.span`
 `;
 
 const LeadStyled = styled.div`
-  ${TextStyles.textR}
+  ${TextStyles.textL}
   margin-top: 48px;
 
   ${up('md')} {
     margin-top: 32px;
-    ${TextStyles.textL}
   }
 `;
 

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -346,7 +346,9 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
       showLanguageSwitch={false}
       breadcrumb={breadcrumb}
     >
-      <BlogHeader headline={blogPost.title} byline={heroByLine} />
+      <BlogHeader headline={blogPost.title} byline={heroByLine}>
+        {blogPost.introText?.introText}
+      </BlogHeader>
       {customContentfulRenderer(blogPost.content)}
 
       <PanelContainer>

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -346,15 +346,17 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
       showLanguageSwitch={false}
       breadcrumb={breadcrumb}
     >
-      <BlogHeader headline={blogPost.title} byline={heroByLine}>
-        {blogPost.introText?.introText}
-      </BlogHeader>
-      {customContentfulRenderer(blogPost.content)}
+      <article>
+        <BlogHeader headline={blogPost.title} byline={heroByLine}>
+          {blogPost.introText?.introText}
+        </BlogHeader>
+        {customContentfulRenderer(blogPost.content)}
 
-      <PanelContainer>
-        <SharePanel title={blogPost.title} />
-        <FollowPanel />
-      </PanelContainer>
+        <PanelContainer>
+          <SharePanel title={blogPost.title} />
+          <FollowPanel />
+        </PanelContainer>
+      </article>
     </Layout>
   );
 };

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -75,6 +75,9 @@ export const BlogPostPageQuery = graphql`
           }
         }
       }
+      introText {
+        introText
+      }
       content {
         raw
         references {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,9 @@ export interface ContentfulCodeBlock {
 
 export interface ContentfulBlogPost {
   author: ContentFulBlogPostAuthor;
+  introText?: {
+    introText: string;
+  };
   content: RenderRichTextData<ContentfulRichTextGatsbyReference>;
   heroImage: ContentfulBlogPostHero;
   id: string;


### PR DESCRIPTION
### What is included?

This PR adds optional introTexts for Blogposts, which are displayed with larger fonts. It can be edited via contentful and is not rendered if it is not provided.  The intro text is also part of the `<header>` of a post

It also wraps the whole blog post into an `<article>` tag just like Zeit and Spiegel do:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/78978542/164449949-a8b1deb6-81e6-4255-b9d2-b33c04a9903e.png">
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/78978542/164450003-29573ba7-034d-4582-9b3e-cd8b9a8c455e.png">


We need this especially for the FCB Case.

### Links
- [Post with Intro Text](https://satellytescommain21751-feataddintrotext.gtsb.io/blog/post/angular-workshop-kaiserx-allianz-2018/)
- [Contentful](https://app.contentful.com/spaces/54dnxp2417nl/entries/6ksCCl23ucIvt29BzA5ka)

### Screenshots
![image](https://user-images.githubusercontent.com/78978542/164449551-ff3819b8-db24-4028-b061-72457de9c9e7.png)


closes #441 