### PR TITLE
feat: improve image quality for full width blog post images

### DIFF
--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -129,8 +129,7 @@ export const BlogPostPageQuery = graphql`
             image {
               contentful_id
               description
-              gatsbyImageData(layout: FULL_WIDTH)
-
+              gatsbyImageData(layout: FULL_WIDTH, quality: 80)
               title
               __typename
             }


### PR DESCRIPTION
The quality for the images can be adjusted with the `quality` variable. It's a value between 1 and 100, the higher the better.

> You can change the quality with the URL parameter. Open your network tab, pick the image URL and set the `q=` parameter to the quality you want to have.
 
The default quality is 50, which makes our full width images on large screens a bit blurry. For those images, we increase the quality to 80. 

Higher quality means higher image size:
- Quality 50: 78kb
- Quality 80: 125kb
- Quality 100: 932kb