### PR TITLE
feat: make selected heroes also have natural height on desktop

### DIFF
--- a/src/components/content/heroes/blog-hero.tsx
+++ b/src/components/content/heroes/blog-hero.tsx
@@ -18,6 +18,7 @@ const coverContainerCss = {
 
 type ImageHeroProps = Partial<HeroWithText> & {
   image: IGatsbyImageData;
+  naturalHeight: boolean;
   attribution?: BlogAttribution;
 };
 
@@ -55,11 +56,12 @@ export const BlogHero = ({
   title,
   children,
   kicker,
+  naturalHeight,
 }: ImageHeroProps) => {
   const gatsbyImageData = getImage(image);
 
   return (
-    <HeroContainer naturalHeight>
+    <HeroContainer naturalHeight={naturalHeight}>
       {gatsbyImageData && (
         <GatsbyImage style={coverContainerCss} alt="" image={gatsbyImageData} />
       )}

--- a/src/components/content/heroes/support.tsx
+++ b/src/components/content/heroes/support.tsx
@@ -17,11 +17,11 @@ export const HeroContainer = styled.div<{ naturalHeight?: boolean }>`
     !naturalHeight &&
     css`
       height: 520px;
-    `}
 
-  ${up('md')} {
-    height: 640px;
-  }
+      ${up('md')} {
+        height: 640px;
+      }
+    `}
 
   overflow: hidden;
   /**

--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -369,6 +369,13 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
   }`;
   const heroByLine = `${formattedDate} • ${readingTime} • ${byLine}`;
 
+  // todo: put this variable into Contentful
+  const heroNaturalHeight =
+    blogPost.id === 'e154c38b-4dfe-5e9b-81ea-9df1c852bb07' ||
+    blogPost.id === '0a0945c4-f5f8-5734-b44e-b6c193ceeee1' ||
+    blogPost.id === 'ca5d5e82-481f-5f6b-acc0-004e567d76c4' ||
+    blogPost.id === 'a60c3422-ba69-5bc2-8da0-5833de3dca39';
+
   return (
     <Layout
       transparentHeader
@@ -378,6 +385,7 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
         <BlogHero
           attribution={blogPost.heroImage}
           image={blogPost.heroImage.fullImage}
+          naturalHeight={heroNaturalHeight}
         />
       }
       leadbox={leadbox}


### PR DESCRIPTION
This is a quick fix. Heros of a blog post now have the `naturalHeight` also on desktop, not only on mobile. This only applies to some selected blog posts. The selection needs to be put into Contentful in the next step (#613) and is hardcoded for now.

Some posts with natural height:
- https://satellytescommain21751-featnaturalheight.gtsb.io/blog/post/fc-bayern-website-frontend-relaunched-by-satellytes/
- https://satellytescommain21751-featnaturalheight.gtsb.io/blog/post/we-work-remotely/

Most blog posts with fixed height:
- https://satellytescommain21751-featnaturalheight.gtsb.io/blog/post/four-ways-to-improve-collaboration-in-your-team/