### PR TITLE
feat: add introText to rss feed

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -169,7 +169,7 @@ const gatsbyConfig: GatsbyConfig = {
                   guid: site.siteMetadata.siteUrl + node.fields.path,
                   custom_elements: [
                     {
-                      'content:encoded': `${coverImage} ${node.rssHtml}`,
+                      'content:encoded': `${coverImage} <p>${node.introText?.introText}</p> ${node.rssHtml}`,
                     },
                   ],
                 };
@@ -196,6 +196,9 @@ const gatsbyConfig: GatsbyConfig = {
                       }
                       creator
                       source
+                    }
+                    introText {
+                      introText
                     }
                   }
                 }


### PR DESCRIPTION
### What is included?
This adds the introText to the content of the rssFeed.

### How to verify
Add [this](https://satellytescommain21751-feataddintrotexttorssfeed.gtsb.io/blog/rss.xml) to Feedly and check if the first Paragraph of the FCB Post is displayed in the preview