### PR TITLE
feat: add naturalHeight flag

### DIFF
--- a/src/components/pages/blog-post/blog-post.tsx
+++ b/src/components/pages/blog-post/blog-post.tsx
@@ -369,13 +369,6 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
   }`;
   const heroByLine = `${formattedDate} • ${readingTime} • ${byLine}`;
 
-  // todo: put this variable into Contentful
-  const heroNaturalHeight =
-    blogPost.id === 'e154c38b-4dfe-5e9b-81ea-9df1c852bb07' ||
-    blogPost.id === '0a0945c4-f5f8-5734-b44e-b6c193ceeee1' ||
-    blogPost.id === 'ca5d5e82-481f-5f6b-acc0-004e567d76c4' ||
-    blogPost.id === 'a60c3422-ba69-5bc2-8da0-5833de3dca39';
-
   return (
     <Layout
       transparentHeader
@@ -385,7 +378,7 @@ export const BlogPostPage = ({ blogPost, breadcrumb }: BlogPostPageProps) => {
         <BlogHero
           attribution={blogPost.heroImage}
           image={blogPost.heroImage.fullImage}
-          naturalHeight={heroNaturalHeight}
+          naturalHeight={blogPost.heroImage.naturalHeight}
         />
       }
       leadbox={leadbox}

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -66,6 +66,7 @@ export const BlogPostPageQuery = graphql`
       heroImage {
         creator
         source
+        naturalHeight
         fullImage: image {
           gatsbyImageData(layout: FULL_WIDTH, placeholder: BLURRED)
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface ContentfulBlogPostHero {
   image: any;
   creator: string;
   source: string;
+  naturalHeight: boolean;
 }
 
 export interface ContentfulCodeBlock {


### PR DESCRIPTION
### what is included?
This lets blog post authors control wether blog Post heros should be displayed with their natural Height via an boolean Flag in [Contentfuls BlogPostHero](https://app.contentful.com/spaces/54dnxp2417nl/entries/4sGFjXqUiwx50GtWfMsSzf?previousEntries=3d3XT4I21AKoLhCe9e90sW)

### How to verify

those blog posts are currently using naturalHeight via Contentful:
- [FCB Case](https://satellytescommain21751-feataddnaturalheightflagconten.gtsb.io/blog/post/fc-bayern-website-frontend-relaunched-by-satellytes/)
- [we work remotely](https://satellytescommain21751-feataddnaturalheightflagconten.gtsb.io/blog/post/we-work-remotely/)
- [Felix Interview](https://satellytescommain21751-feataddnaturalheightflagconten.gtsb.io/blog/post/interview-felix-hamann/)
- [Daniel Interview](https://satellytescommain21751-feataddnaturalheightflagconten.gtsb.io/blog/post/interview-daniel-eissing/)

some blog posts without natural height:
- [Code Reviewer](https://satellytescommain21751-feataddnaturalheightflagconten.gtsb.io/blog/post/the-modern-code-reviewer-2021/)
- [Improve Collaboration](https://satellytescommain21751-feataddnaturalheightflagconten.gtsb.io/blog/post/four-ways-to-improve-collaboration-in-your-team/)