### PR TITLE
Feat/add parallax

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "gatsby-transformer-json": "^4.13.0",
     "gatsby-transformer-remark": "^5.13.0",
     "gatsby-transformer-sharp": "^4.13.0",
+    "gbimage-bridge": "^0.2.1",
     "html-entities": "^2.3.2",
     "i18next": "^21.6.16",
     "leaflet": "^1.8.0",

--- a/src/components/pages/landingpage/image-spacer.tsx
+++ b/src/components/pages/landingpage/image-spacer.tsx
@@ -37,5 +37,9 @@ export const ParallaxImageSpacer = ({ image }) => {
   const gatsbyImageData = getImage(image);
   const bgImage = convertToBgImage(gatsbyImageData);
 
-  return <StyledBackgroundImage {...bgImage} preserveStackingContext />;
+  return (
+    // eslint-disable-next-line
+    // @ts-ignore get rid of "error TS2589: Type instantiation is excessively deep and possibly infinite."
+    <StyledBackgroundImage fluid={bgImage?.fluid} preserveStackingContext />
+  );
 };

--- a/src/components/pages/landingpage/image-spacer.tsx
+++ b/src/components/pages/landingpage/image-spacer.tsx
@@ -1,50 +1,9 @@
 import styled from 'styled-components';
 import { up } from '../../support/breakpoint';
-import { GatsbyImage, getImage } from 'gatsby-plugin-image';
+import { getImage } from 'gatsby-plugin-image';
 import { convertToBgImage } from 'gbimage-bridge';
 import BackgroundImage from 'gatsby-background-image';
 import React from 'react';
-
-const coverContainerCss = {
-  gridArea: '1/1',
-};
-
-const ImageContainer = styled.div`
-  /**
-    We enforce a higher specificity with \`&&\` (repeat the classname two times) to overrule the layout main rule of assigning any content to a specific column \`> *{  grid-column: content; }\` in the grid
-    which we want to escape to spread over the full width.
-
-    Do not remove easily. The actual order of CSS rules is not stable
-    and the two rules (from the layout and this) will have the same specificity.
-   */
-  && {
-    grid-column: -1/1;
-  }
-
-  display: grid;
-  height: 210px;
-  margin-top: 80px;
-
-  ${up('md')} {
-    height: 360px;
-    margin-top: 180px;
-  }
-`;
-
-/**
- * Display any given gatsby image as a spacer that covers the entire width
- */
-export const ImageSpacer = ({ image }) => {
-  const gatsbyImageData = getImage(image);
-
-  return (
-    <ImageContainer>
-      {gatsbyImageData && (
-        <GatsbyImage style={coverContainerCss} alt="" image={gatsbyImageData} />
-      )}
-    </ImageContainer>
-  );
-};
 
 const StyledBackgroundImage = styled(BackgroundImage)`
   background-attachment: fixed;
@@ -72,28 +31,11 @@ const StyledBackgroundImage = styled(BackgroundImage)`
     height: 360px;
     margin-top: 180px;
   }
-
-  picture {
-    position: relative;
-  }
 `;
 
 export const ParallaxImageSpacer = ({ image }) => {
   const gatsbyImageData = getImage(image);
-
-  // Use like this:
   const bgImage = convertToBgImage(gatsbyImageData);
 
-  return (
-    <StyledBackgroundImage
-      Tag="section"
-      // Spread bgImage into BackgroundImage:
-      {...bgImage}
-      preserveStackingContext
-    >
-      {gatsbyImageData && (
-        <GatsbyImage image={gatsbyImageData} alt={'testimage'} />
-      )}
-    </StyledBackgroundImage>
-  );
+  return <StyledBackgroundImage {...bgImage} preserveStackingContext />;
 };

--- a/src/components/pages/landingpage/image-spacer.tsx
+++ b/src/components/pages/landingpage/image-spacer.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import { up } from '../../support/breakpoint';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
+import { convertToBgImage } from 'gbimage-bridge';
+import BackgroundImage from 'gatsby-background-image';
 import React from 'react';
 
 const coverContainerCss = {
@@ -11,9 +13,9 @@ const ImageContainer = styled.div`
   /**
     We enforce a higher specificity with \`&&\` (repeat the classname two times) to overrule the layout main rule of assigning any content to a specific column \`> *{  grid-column: content; }\` in the grid
     which we want to escape to spread over the full width.
-    
+
     Do not remove easily. The actual order of CSS rules is not stable
-    and the two rules (from the layout and this) will have the same specificity. 
+    and the two rules (from the layout and this) will have the same specificity.
    */
   && {
     grid-column: -1/1;
@@ -41,5 +43,57 @@ export const ImageSpacer = ({ image }) => {
         <GatsbyImage style={coverContainerCss} alt="" image={gatsbyImageData} />
       )}
     </ImageContainer>
+  );
+};
+
+const StyledBackgroundImage = styled(BackgroundImage)`
+  background-attachment: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+
+  /**
+    We enforce a higher specificity with \`&&\` (repeat the classname two times) to overrule the layout main rule of assigning any content to a specific column \`> *{  grid-column: content; }\` in the grid
+    which we want to escape to spread over the full width.
+
+    Do not remove easily. The actual order of CSS rules is not stable
+    and the two rules (from the layout and this) will have the same specificity.
+   */
+  && {
+    grid-column: -1/1;
+  }
+
+  display: grid;
+
+  height: 210px;
+  margin-top: 80px;
+
+  ${up('md')} {
+    height: 360px;
+    margin-top: 180px;
+  }
+
+  picture {
+    position: relative;
+  }
+`;
+
+export const ParallaxImageSpacer = ({ image }) => {
+  const gatsbyImageData = getImage(image);
+
+  // Use like this:
+  const bgImage = convertToBgImage(gatsbyImageData);
+
+  return (
+    <StyledBackgroundImage
+      Tag="section"
+      // Spread bgImage into BackgroundImage:
+      {...bgImage}
+      preserveStackingContext
+    >
+      {gatsbyImageData && (
+        <GatsbyImage image={gatsbyImageData} alt={'testimage'} />
+      )}
+    </StyledBackgroundImage>
   );
 };

--- a/src/components/pages/landingpage/image-spacer.tsx
+++ b/src/components/pages/landingpage/image-spacer.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
 import { up } from '../../support/breakpoint';
 import { getImage } from 'gatsby-plugin-image';
-import { convertToBgImage } from 'gbimage-bridge';
-import BackgroundImage from 'gatsby-background-image';
-import React from 'react';
+import { BgImage } from 'gbimage-bridge';
+import React, { useEffect, useState } from 'react';
 
-const StyledBackgroundImage = styled(BackgroundImage)`
+const StyledBackgroundImage = styled(BgImage)`
   background-attachment: fixed;
   background-position: center;
   background-repeat: no-repeat;
@@ -34,12 +33,16 @@ const StyledBackgroundImage = styled(BackgroundImage)`
 `;
 
 export const ParallaxImageSpacer = ({ image }) => {
+  const [isBrowser, setIsBrowser] = useState(false);
+
+  useEffect(() => {
+    setIsBrowser(true);
+  });
   const gatsbyImageData = getImage(image);
-  const bgImage = convertToBgImage(gatsbyImageData);
+
+  if (!isBrowser) return null;
 
   return (
-    // eslint-disable-next-line
-    // @ts-ignore get rid of "error TS2589: Type instantiation is excessively deep and possibly infinite."
-    <StyledBackgroundImage {...bgImage} />
+    <>{gatsbyImageData && <StyledBackgroundImage image={gatsbyImageData} />}</>
   );
 };

--- a/src/components/pages/landingpage/image-spacer.tsx
+++ b/src/components/pages/landingpage/image-spacer.tsx
@@ -40,6 +40,6 @@ export const ParallaxImageSpacer = ({ image }) => {
   return (
     // eslint-disable-next-line
     // @ts-ignore get rid of "error TS2589: Type instantiation is excessively deep and possibly infinite."
-    <StyledBackgroundImage fluid={bgImage?.fluid} preserveStackingContext />
+    <StyledBackgroundImage {...bgImage} />
   );
 };

--- a/src/components/pages/landingpage/landingpage.tsx
+++ b/src/components/pages/landingpage/landingpage.tsx
@@ -8,7 +8,7 @@ import { Service } from './service';
 import { Blog } from './blog';
 import { BlogPostTeaser, SyPersonioJob } from '../../../types';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
-import { ImageSpacer } from './image-spacer';
+import { ImageSpacer, ParallaxImageSpacer } from './image-spacer';
 
 interface OfficeImage {
   relativePath: string;
@@ -44,13 +44,13 @@ export const Landingpage = ({
         <Service />
       </ContentBlockContainer>
 
-      <ImageSpacer image={officeImages['office/sy-office-01.jpg']} />
+      <ParallaxImageSpacer image={officeImages['office/sy-office-01.jpg']} />
 
       <ContentBlockContainer>
         <Career positions={positions} />
       </ContentBlockContainer>
 
-      <ImageSpacer image={officeImages['office/sy-office-02.jpg']} />
+      <ParallaxImageSpacer image={officeImages['office/sy-office-02.jpg']} />
 
       <ContentBlockContainer>
         <Blog posts={posts} />

--- a/src/components/pages/landingpage/landingpage.tsx
+++ b/src/components/pages/landingpage/landingpage.tsx
@@ -8,7 +8,7 @@ import { Service } from './service';
 import { Blog } from './blog';
 import { BlogPostTeaser, SyPersonioJob } from '../../../types';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
-import { ImageSpacer, ParallaxImageSpacer } from './image-spacer';
+import { ParallaxImageSpacer } from './image-spacer';
 
 interface OfficeImage {
   relativePath: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9991,6 +9991,11 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gbimage-bridge@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/gbimage-bridge/-/gbimage-bridge-0.2.1.tgz#3bb44a4eb06855f1a8c23db5396d710352acaf05"
+  integrity sha512-Wy7fiXyYewxzgs17Mx+msSbxSK8JGbkVDQmkuyXER6T3wfZHC04PLnzP1ZrFr7qpboOdIExUChp3TZtzRor4AA==
+
 generate-robotstxt@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/generate-robotstxt/-/generate-robotstxt-8.0.3.tgz#83384090406e760e9d02247412b2b704562c9b58"


### PR DESCRIPTION
### What is included?

- add gbimage-bridge as dependency like suggested [here](https://www.gatsbyjs.com/plugins/gatsby-background-image/#how-to-use)
- use gatsby-image-background to build a parallax component
- use Parallax on LandingPage for the Spacers
- the parallax is only rendered in the browser to prevent [this](https://reactjs.org/docs/error-decoder.html/?invariant=418) error

### Disclaimer

The parallax does not work on Safari, since it does not support `background-attachement: fixed` ([reference](https://caniuse.com/?search=background-attachment))

### Further Thoughts

The effect looks a little weird on mobile and on some mobile browsers does not work properly.
I suggest to think of using another image for mobile devices or disabling this effect on mobile.