### PR TITLE
fix: introRichText in rssFeed

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -169,7 +169,7 @@ const gatsbyConfig: GatsbyConfig = {
                   guid: site.siteMetadata.siteUrl + node.fields.path,
                   custom_elements: [
                     {
-                      'content:encoded': `${coverImage} <p>${node.introText?.introText}</p> ${node.rssHtml}`,
+                      'content:encoded': `${coverImage} ${node.rssHtml}`,
                     },
                   ],
                 };
@@ -196,9 +196,6 @@ const gatsbyConfig: GatsbyConfig = {
                       }
                       creator
                       source
-                    }
-                    introText {
-                      introText
                     }
                   }
                 }

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -122,25 +122,25 @@ export const createResolvers = ({ createResolvers }) => {
       plainText: {
         type: 'String',
         resolve: (source) => {
-          {
-            source.introRichText
-              ? documentToPlainTextString(
-                  JSON.parse(source.introRichText.raw),
-                ) + ' '
-              : '';
-          }
-          +documentToPlainTextString(JSON.parse(source.content.raw));
+          const intro = source.introRichText
+            ? documentToPlainTextString(JSON.parse(source.introRichText.raw))
+            : '';
+
+          const content = documentToPlainTextString(
+            JSON.parse(source.content.raw),
+          );
+          return intro + ' ' + content;
         },
       },
       rssHtml: {
         type: 'String',
         resolve: (source) => {
-          {
-            source.introRichText
-              ? documentToHtmlString(JSON.parse(source.introRichText.raw)) + ' '
-              : '';
-          }
-          +documentToHtmlString(JSON.parse(source.content.raw));
+          const intro = source.introRichText
+            ? documentToHtmlString(JSON.parse(source.introRichText.raw))
+            : '';
+
+          const content = documentToHtmlString(JSON.parse(source.content.raw));
+          return intro + content;
         },
       },
     },

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -121,17 +121,27 @@ export const createResolvers = ({ createResolvers }) => {
     ContentfulBlogPost: {
       plainText: {
         type: 'String',
-        resolve: (source) =>
-          documentToPlainTextString(
-            JSON.parse(source.introRichText.raw + source.content.raw),
-          ),
+        resolve: (source) => {
+          {
+            source.introRichText
+              ? documentToPlainTextString(
+                  JSON.parse(source.introRichText.raw),
+                ) + ' '
+              : '';
+          }
+          +documentToPlainTextString(JSON.parse(source.content.raw));
+        },
       },
       rssHtml: {
         type: 'String',
-        resolve: (source) =>
-          documentToHtmlString(
-            JSON.parse(source.introRichText.raw + source.content.raw),
-          ),
+        resolve: (source) => {
+          {
+            source.introRichText
+              ? documentToHtmlString(JSON.parse(source.introRichText.raw)) + ' '
+              : '';
+          }
+          +documentToHtmlString(JSON.parse(source.content.raw));
+        },
       },
     },
   });

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -122,12 +122,16 @@ export const createResolvers = ({ createResolvers }) => {
       plainText: {
         type: 'String',
         resolve: (source) =>
-          documentToPlainTextString(JSON.parse(source.content.raw)),
+          documentToPlainTextString(
+            JSON.parse(source.introRichText.raw + source.content.raw),
+          ),
       },
       rssHtml: {
         type: 'String',
         resolve: (source) =>
-          documentToHtmlString(JSON.parse(source.content.raw)),
+          documentToHtmlString(
+            JSON.parse(source.introRichText.raw + source.content.raw),
+          ),
       },
     },
   });


### PR DESCRIPTION
### What is included?

This adds the new introRichText field to the rssFeed.

### How to verify?

add [this](https://satellytescommain21751-featfixintroinrss.gtsb.io/blog/rss.xml) to your [feedly](https://feedly.com/) and verify that the intro text of e.g. the [fcb case](https://satellytescommain21751-featfixintroinrss.gtsb.io/blog/post/fc-bayern-website-frontend-relaunched-by-satellytes/) is there