### PR TITLE
fix(graphql): show team members only once

### DIFF
--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -38,7 +38,7 @@ export const AboutUsPageQuery = graphql`
       }
     }
 
-    allContentfulTeamMember {
+    allContentfulTeamMember(filter: { node_locale: { eq: "en" } }) {
       nodes {
         id
         name

--- a/src/templates/blog-post-overview.tsx
+++ b/src/templates/blog-post-overview.tsx
@@ -54,6 +54,7 @@ export default Blog;
 export const BlogPageQuery = graphql`
   query ($language: String!, $skip: Int!, $limit: Int!) {
     allContentfulBlogPost(
+      filter: { node_locale: { eq: "en" } }
       sort: { fields: publicationDate, order: DESC }
       limit: $limit
       skip: $skip


### PR DESCRIPTION
Something introduced a bug where our team members are renders multiple times depending on our locales. By filtering the node_locale we can make sure that that the list doesn't contain duplicates.