### PR TITLE
fix(Blog): show correct amount of pages in pagination

### DIFF
--- a/gatsby/create-pages/create-blog-post-overview-pages.ts
+++ b/gatsby/create-pages/create-blog-post-overview-pages.ts
@@ -29,7 +29,10 @@ export const createBlogPostOverviewPages = async ({
     };
   }>(`
     {
-      allContentfulBlogPost(sort: { fields: publicationDate, order: DESC }) {
+      allContentfulBlogPost(
+        filter: { node_locale: { eq: "en" } }
+        sort: { fields: publicationDate, order: DESC }
+      ) {
         nodes {
           fields {
             path


### PR DESCRIPTION
### What is the problem?
* The last two pages on the [blog overview pagination](https://satellytes.com/blog/page/3/) don’t have any content
<img width="1749" alt="Bildschirmfoto 2022-10-13 um 17 23 52" src="https://user-images.githubusercontent.com/57712895/195638658-452152ea-ddb0-4ecd-b3d4-2966ebf914e7.png">


### How it is solved:
* In https://github.com/satellytes/satellytes.com/pull/666, for images of the team members and for the blogpost overview, the double rendering of the content was avoided by filtering the `node_locale`
* The data for pagination comes from `create-blog-post-overview-pages.ts`, where the missing filter has now been added

### Preview: 
* URL: tbd
