### PR TITLE
fix(Landingpage): show blogpost teasers only once

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,6 +74,7 @@ export const IndexPageQuery = graphql`
     }
 
     allContentfulBlogPost(
+      filter: { node_locale: { eq: "en" } }
       sort: { fields: publicationDate, order: DESC }
       limit: 3
     ) {


### PR DESCRIPTION
### What is the problem?
* The blog teasers on our [landing page](https://satellytes.com/) are displayed twice
<img width="2035" alt="Bildschirmfoto 2022-10-26 um 12 19 30" src="https://user-images.githubusercontent.com/57712895/198001745-93c56f4a-ad8c-4188-b151-d796f7f3658b.png">

### How it is solved?
* Like in https://github.com/satellytes/satellytes.com/pull/666 and https://github.com/satellytes/satellytes.com/pull/671 the `node_locale` is filtered now

Preview URL: https://satellytescommain21751-fixremoveduplicateblogteasers.gtsb.io/