### PR TITLE
chore: expect node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn' 
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git@github.com:satellytes/satellytes.com.git"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": "please-use-yarn",
     "yarn": "^1.0.0"
   },


### PR DESCRIPTION
* The `dependency-update` action failed with this error message:
```error gatsby@5.0.1: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.18.0"```
(https://github.com/satellytes/satellytes.com/actions/runs/3458079706/jobs/5772136982)
* We now expect node 18 in the `package.json` so the action should also be executed with node 18