### PR TITLE
chore: set node 18 in scheduled dependency update action

### DIFF
--- a/.github/workflows/update-npm.yml
+++ b/.github/workflows/update-npm.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
       - name: Upgrade dependencies
         run: yarn upgrade --latest --caret
 


### PR DESCRIPTION
In https://github.com/satellytes/satellytes.com/pull/679 we set the expected node version in `package.json` to `>=18`. This should fix the [dependency update action](https://github.com/satellytes/satellytes.com/actions/runs/3470583117/jobs/5798962690). However, despite the changes in package.json, node 16 is used by the action. Therefore, in this PR, the node version is explicitly set to 18 in the action's script.