### PR TITLE
feat: add field applicantLocationRequirements to job data

### DIFF
--- a/src/components/pages/career-details/career-details-structured-data.tsx
+++ b/src/components/pages/career-details/career-details-structured-data.tsx
@@ -71,6 +71,10 @@ export const CareerDetailsStructuredData = ({
       },
     },
     jobLocationType: 'TELECOMMUTE',
+    applicantLocationRequirements: {
+      '@type': 'Country',
+      name: 'EU',
+    },
     employmentType: normalizeJobScheduleFormat(position.schedule),
     directApply: true,
   };


### PR DESCRIPTION
Google needs a mandatory field "applicantLocationRequirements" which was missing in our Job Postings structured Data. 
See [Google Search Console](https://search.google.com/search-console/r/jobs?resource_id=sc-domain%3Asatellytes.com) for reference.

I added the field with the value "EU" as Location Requirement. Validate the Markup by using [googles validator](https://search.google.com/test/rich-results)