### PR TITLE
feat: adjust structured data

### DIFF
--- a/src/components/pages/career-details/career-details-structured-data.tsx
+++ b/src/components/pages/career-details/career-details-structured-data.tsx
@@ -57,7 +57,8 @@ export const CareerDetailsStructuredData = ({
     hiringOrganization: {
       '@type': 'Organization',
       name: 'Satellytes Digital Consulting GmbH',
-      sameAs: 'http://www.satellytes.com',
+      sameAs: 'https://satellytes.com',
+      logo: 'https://satellytes.com/sy-logo.png',
     },
     jobLocation: {
       '@type': 'Place',
@@ -73,7 +74,7 @@ export const CareerDetailsStructuredData = ({
     jobLocationType: 'TELECOMMUTE',
     applicantLocationRequirements: {
       '@type': 'Country',
-      name: 'EU',
+      name: 'DE',
     },
     employmentType: normalizeJobScheduleFormat(position.schedule),
     directApply: true,


### PR DESCRIPTION
This PR changes the "applicantLocationRequirement" of JobPostings to "DE" and adds a logo prop. Our logo has not been displayed on google jobs even though it is placed as Structured data on the landingpage. LinkedIn also puts the logo on the Job page itself. Therefore I added it there too.