### PR TITLE
fix: footer won't stick to bottom of the page

### DIFF
--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -21,6 +21,7 @@ import { useAnchorTagScrolling } from './use-anchor-tag-scrolling';
 const FullHeightContainer = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 
   min-height: 100vh;
 


### PR DESCRIPTION
The footer now stays at the bottom of the page at all times.