### PR TITLE
feat(CareerPage): new teaser grid design

### DIFF
--- a/src/components/pages/career/career-teaser-grid.tsx
+++ b/src/components/pages/career/career-teaser-grid.tsx
@@ -1,16 +1,17 @@
 import styled from 'styled-components';
 import { up } from '../../support/breakpoint';
 
-export const CareerTeaserGrid = styled.div<{ amountOfChildren: number }>`
+export const CareerTeaserGrid = styled.div`
   display: grid;
   gap: 72px;
-  grid-template-columns: ${(props) =>
-    `repeat(${props.amountOfChildren}, 242px)`};
+  grid-auto-flow: column;
+  grid-auto-columns: 242px;
   overflow-x: auto;
   margin: 0 -24px;
   padding: 0 24px;
 
   ${up('md')} {
+    grid-auto-flow: row;
     grid-template-columns: repeat(auto-fit, minmax(242px, 1fr));
     margin: 0;
     padding: 0;

--- a/src/components/pages/career/career-teaser-grid.tsx
+++ b/src/components/pages/career/career-teaser-grid.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { up } from '../../support/breakpoint';
+
+export const CareerTeaserGrid = styled.div<{ amountOfChildren: number }>`
+  display: grid;
+  gap: 72px;
+  grid-template-columns: ${(props) =>
+    `repeat(${props.amountOfChildren}, 242px)`};
+  overflow-x: auto;
+  margin: 0 -24px;
+  padding: 0 24px;
+
+  ${up('md')} {
+    grid-template-columns: repeat(auto-fit, minmax(242px, 1fr));
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+  }
+`;

--- a/src/components/pages/career/culture.tsx
+++ b/src/components/pages/career/culture.tsx
@@ -5,29 +5,13 @@ import { Teaser } from '../../content/teaser/teaser';
 import { IllustrationType } from '../../ui/illustration/illustration-set';
 import { SectionHeader } from '../../content/section-header/section-header';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { CareerTeaserGrid } from './career-teaser-grid';
 
 interface CultureAspect {
   illustration: IllustrationType;
   title: string;
   description: string;
 }
-
-const TeaserGrid = styled.div`
-  display: grid;
-  gap: 24px;
-
-  justify-items: stretch;
-  grid-template-columns: 1fr;
-
-  ${up('sm')} {
-    grid-template-columns: repeat(auto-fit, 250px);
-  }
-
-  ${up('md')} {
-    gap: 70px;
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-`;
 
 const ASPECTS = (t): CultureAspect[] => [
   {
@@ -66,12 +50,17 @@ const ASPECTS = (t): CultureAspect[] => [
   },
 ];
 
-const CultureTeaserGrid = styled(TeaserGrid)`
+const CultureTeaserGrid = styled(CareerTeaserGrid)`
   margin-top: 48px;
+  ${up('md')} {
+    margin-top: 60px;
+  }
 `;
 
 export const Culture = () => {
   const { t } = useTranslation();
+  const amountOfTeasers = ASPECTS(t).length;
+
   return (
     <>
       <SectionHeader
@@ -81,7 +70,7 @@ export const Culture = () => {
         {t('career.culture.paragraph')}
       </SectionHeader>
 
-      <CultureTeaserGrid>
+      <CultureTeaserGrid amountOfChildren={amountOfTeasers}>
         {ASPECTS(t).map((item, index) => (
           <Teaser
             title={item.title}

--- a/src/components/pages/career/culture.tsx
+++ b/src/components/pages/career/culture.tsx
@@ -59,7 +59,6 @@ const CultureTeaserGrid = styled(CareerTeaserGrid)`
 
 export const Culture = () => {
   const { t } = useTranslation();
-  const amountOfTeasers = ASPECTS(t).length;
 
   return (
     <>
@@ -70,7 +69,7 @@ export const Culture = () => {
         {t('career.culture.paragraph')}
       </SectionHeader>
 
-      <CultureTeaserGrid amountOfChildren={amountOfTeasers}>
+      <CultureTeaserGrid>
         {ASPECTS(t).map((item, index) => (
           <Teaser
             title={item.title}

--- a/src/components/pages/career/openings.tsx
+++ b/src/components/pages/career/openings.tsx
@@ -31,12 +31,11 @@ interface OpeningsProps {
 
 export const Openings = (props: OpeningsProps) => {
   const { t } = useTranslation();
-  const amountOfTeasers = props.jobs.length;
 
   return (
     <div>
       <SectionHeadline>{t('career.openings.headline')}</SectionHeadline>
-      <OpeningsTeaseGrid amountOfChildren={amountOfTeasers}>
+      <OpeningsTeaseGrid>
         {props.jobs.map((item) => (
           <Teaser title={item.name} linkTo={item.slug} key={item.id}>
             {item.short}

--- a/src/components/pages/career/openings.tsx
+++ b/src/components/pages/career/openings.tsx
@@ -4,16 +4,24 @@ import styled from 'styled-components';
 import { TextStyles } from '../../typography';
 import { SyPersonioJob } from '../../../types';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { TeaserGrid } from '../../content/teaser/teaser-grid';
 import { up } from '../../support/breakpoint';
+import { CareerTeaserGrid } from './career-teaser-grid';
 
 const SectionHeadline = styled.h2`
   ${TextStyles.headlineL}
   margin: 0;
-  margin-bottom: 80px;
+  margin-bottom: 48px;
 
   ${up('md')} {
     ${TextStyles.headlineXL}
+  }
+`;
+
+const OpeningsTeaseGrid = styled(CareerTeaserGrid)`
+  margin-top: 48px;
+
+  ${up('md')} {
+    margin-top: 60px;
   }
 `;
 
@@ -23,16 +31,18 @@ interface OpeningsProps {
 
 export const Openings = (props: OpeningsProps) => {
   const { t } = useTranslation();
+  const amountOfTeasers = props.jobs.length;
+
   return (
     <div>
       <SectionHeadline>{t('career.openings.headline')}</SectionHeadline>
-      <TeaserGrid>
+      <OpeningsTeaseGrid amountOfChildren={amountOfTeasers}>
         {props.jobs.map((item) => (
           <Teaser title={item.name} linkTo={item.slug} key={item.id}>
             {item.short}
           </Teaser>
         ))}
-      </TeaserGrid>
+      </OpeningsTeaseGrid>
     </div>
   );
 };

--- a/src/components/pages/career/perks.tsx
+++ b/src/components/pages/career/perks.tsx
@@ -61,7 +61,6 @@ const PerksTeaserGrid = styled(CareerTeaserGrid)`
 
 export const Perks = () => {
   const { t } = useTranslation();
-  const amountOfTeasers = PERKS(t).length;
 
   return (
     <>
@@ -72,7 +71,7 @@ export const Perks = () => {
         {t('career.perk.paragraph')}
       </SectionHeader>
 
-      <PerksTeaserGrid amountOfChildren={amountOfTeasers}>
+      <PerksTeaserGrid>
         {PERKS(t).map((item, index) => (
           <Teaser
             title={item.title}

--- a/src/components/pages/career/perks.tsx
+++ b/src/components/pages/career/perks.tsx
@@ -5,29 +5,13 @@ import { up } from '../../support/breakpoint';
 import { IllustrationType } from '../../ui/illustration/illustration-set';
 import { SectionHeader } from '../../content/section-header/section-header';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { CareerTeaserGrid } from './career-teaser-grid';
 
 interface Perk {
   illustration: IllustrationType;
   title: string;
   description: string;
 }
-
-const TeaserGrid = styled.div`
-  display: grid;
-  gap: 24px;
-
-  justify-items: stretch;
-  grid-template-columns: 1fr;
-
-  ${up('sm')} {
-    grid-template-columns: repeat(auto-fit, 250px);
-  }
-
-  ${up('md')} {
-    gap: 70px;
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-`;
 
 const PERKS = (t): Perk[] => [
   {
@@ -67,12 +51,18 @@ const PERKS = (t): Perk[] => [
   },
 ];
 
-const PerksTeaserGrid = styled(TeaserGrid)`
+const PerksTeaserGrid = styled(CareerTeaserGrid)`
   margin-top: 48px;
+
+  ${up('md')} {
+    margin-top: 60px;
+  }
 `;
 
 export const Perks = () => {
   const { t } = useTranslation();
+  const amountOfTeasers = PERKS(t).length;
+
   return (
     <>
       <SectionHeader
@@ -82,7 +72,7 @@ export const Perks = () => {
         {t('career.perk.paragraph')}
       </SectionHeader>
 
-      <PerksTeaserGrid>
+      <PerksTeaserGrid amountOfChildren={amountOfTeasers}>
         {PERKS(t).map((item, index) => (
           <Teaser
             title={item.title}


### PR DESCRIPTION
### What's included?
* The Openings, Culture and Perks sections have a new design now:
  * Mobile: Teasers are displayed with horizontal scrolling
  * Desktop: Teasers have a larger width and the grid fills up all the available space

### Preview
* URL: https://satellytescomfeatmaindesignupd-featcareerteasergrid.gatsbyjs.io/career/
* Mobile
<img width="877" alt="Bildschirm­foto 2023-03-01 um 10 58 40" src="https://user-images.githubusercontent.com/57712895/222106223-5fd1bdac-3ebd-46b1-810f-81ccfd534ed8.png">

* Desktop
  * ℹ️ In the deployment preview, the grid is currently only two columns wide, because the entire content still has the old (smaller) width. If this is adjusted, the implementation fits to the design (see screenshot). 
<img width="2417" alt="Bildschirm­foto 2023-03-01 um 11 00 19" src="https://user-images.githubusercontent.com/57712895/222106649-32f70a2c-5b89-4457-a66d-621c7ca8a88a.png">

