### PR TITLE
feat(CareerPage): new vacancies grid design

### DIFF
--- a/src/components/pages/career/openings.tsx
+++ b/src/components/pages/career/openings.tsx
@@ -4,16 +4,27 @@ import styled from 'styled-components';
 import { TextStyles } from '../../typography';
 import { SyPersonioJob } from '../../../types';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { TeaserGrid } from '../../content/teaser/teaser-grid';
 import { up } from '../../support/breakpoint';
 
 const SectionHeadline = styled.h2`
   ${TextStyles.headlineL}
   margin: 0;
-  margin-bottom: 80px;
+  margin-bottom: 48px;
 
   ${up('md')} {
     ${TextStyles.headlineXL}
+    margin-bottom: 60px;
+  }
+`;
+
+const TeaserGrid = styled.div`
+  display: grid;
+  gap: 48px;
+  grid-template-columns: 1fr;
+
+  ${up('md')} {
+    grid-template-columns: repeat(auto-fit, minmax(242px, 1fr));
+    gap: 72px;
   }
 `;
 


### PR DESCRIPTION
### What's included?
* The openings section has a new design now:
  * Mobile: Teasers are displayed without horizontal scrolling
  * Desktop: Teasers have a larger width and the grid fills up all the available space

### Preview
* Mobile
<img width="1091" alt="Bildschirm­foto 2023-03-01 um 12 13 24" src="https://user-images.githubusercontent.com/57712895/222123637-fb3aca56-63f9-48d7-8ff2-061118cb1c0d.png">

* Desktop
  * ℹ️ In the deployment preview, the grid is currently only two columns wide, because the entire content still has the old (smaller) width. If this is adjusted, the implementation fits to the design (see screenshot). 
<img width="1746" alt="Bildschirm­foto 2023-03-01 um 12 15 14" src="https://user-images.githubusercontent.com/57712895/222124076-144ba5a7-f674-4a2a-98d2-5bb82c4ccf92.png">

