### PR TITLE
feat: Font size changes for an updated design

### DIFF
--- a/src/components/content/header-block/header-block.tsx
+++ b/src/components/content/header-block/header-block.tsx
@@ -41,19 +41,24 @@ const IconWrapper = styled.div`
 `;
 
 const Topline = styled.p`
-  ${TextStyles.toplineR}
+  ${TextStyles.toplineS}
   color: #3e61ee;
   margin: 0;
+
+  ${up('md')} {
+    ${TextStyles.toplineR}
+  }
 `;
 
 const Headline = styled.h2<LargeProps>`
-  ${TextStyles.headlineL}
+  ${TextStyles.headlineM}
   letter-spacing: -0.01em;
   color: #202840;
   margin-top: 16px;
   margin-bottom: ${({ large }) => (large ? '32px' : '16px')};
+
   ${up('md')} {
-    ${TextStyles.headlineXL}
+    ${TextStyles.headlineL}
   }
 `;
 
@@ -65,7 +70,11 @@ const Metaline = styled.p<LargeProps>`
 `;
 
 const HeaderBlockText = styled.p<LargeProps>`
-  ${({ large }) => (large ? TextStyles.textL : TextStyles.textR)};
+  ${({ large }) => (large ? TextStyles.textSR : TextStyles.textS)};
+
+  ${up('md')} {
+    ${({ large }) => (large ? TextStyles.textR : TextStyles.textSR)};
+  }
 
   letter-spacing: -0.01em;
   color: #202840;

--- a/src/components/content/section-header/section-header.tsx
+++ b/src/components/content/section-header/section-header.tsx
@@ -30,29 +30,33 @@ interface SectionHeaderProps {
 }
 
 const KickerStyled = styled.span`
-  ${TextStyles.toplineR}
+  ${TextStyles.toplineS}
   display: block;
   color: #3e61ee;
   margin-bottom: 16px;
+
+  ${up('md')} {
+    ${TextStyles.toplineR}
+  }
 `;
 
 const HeadlineStyled = styled.h2`
-  ${TextStyles.headlineL}
+  ${TextStyles.headlineM}
   margin: 0;
   color: #202840;
   margin-bottom: 24px;
 
   ${up('md')} {
     margin-bottom: 32px;
-    ${TextStyles.headlineXL}
+    ${TextStyles.headlineL}
   }
 `;
 
 const ContentStyled = styled.div`
-  ${TextStyles.textR}
+  ${TextStyles.textSR}
 
   ${up('md')} {
-    ${TextStyles.textL}
+    ${TextStyles.textR}
   }
 `;
 

--- a/src/components/content/teaser/teaser.tsx
+++ b/src/components/content/teaser/teaser.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../ui/illustration/illustration';
 import { Icon } from '../../ui/icon/icon';
 import { TextStyles } from '../../typography';
+import { up } from '../../support/breakpoint';
 
 const TeaserContainer = styled.div<{ hover: boolean }>`
   overflow: hidden;
@@ -69,8 +70,13 @@ const StyledTeaserTitle = styled.h3<{
   large: boolean;
   hasTopline: boolean;
 }>`
-  ${TextStyles.headlineS}
-  ${(props) => props.large && TextStyles.headlineM};
+  ${TextStyles.headlineXS}
+
+  ${(props) => props.large && TextStyles.headlineXS};
+
+  ${up('md')} {
+    ${(props) => props.large && TextStyles.headlineM};
+  }
 
   margin-top: 0;
   margin-bottom: ${(props) => (props.hasTopline ? '8px' : '16px')};

--- a/src/components/forms/file-dropper/file-list-item.tsx
+++ b/src/components/forms/file-dropper/file-list-item.tsx
@@ -32,7 +32,7 @@ const FileListItemContainer = styled.div`
 `;
 
 const FileName = styled.p`
-  ${TextStyles.headlineXS};
+  ${TextStyles.headlineXXS};
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/pages/career/openings.tsx
+++ b/src/components/pages/career/openings.tsx
@@ -8,12 +8,12 @@ import { TeaserGrid } from '../../content/teaser/teaser-grid';
 import { up } from '../../support/breakpoint';
 
 const SectionHeadline = styled.h2`
-  ${TextStyles.headlineL}
+  ${TextStyles.headlineM}
   margin: 0;
   margin-bottom: 80px;
 
   ${up('md')} {
-    ${TextStyles.headlineXL}
+    ${TextStyles.headlineL}
   }
 `;
 

--- a/src/components/typography.ts
+++ b/src/components/typography.ts
@@ -45,7 +45,16 @@ export const TextStyles = {
 
     letter-spacing: -0.01em;
   `,
+
   headlineXS: css`
+    font-weight: bold;
+    font-size: 20px;
+    line-height: 110%;
+
+    letter-spacing: -0.01em;
+  `,
+
+  headlineXXS: css`
     font-weight: bold;
     font-size: 16px;
     line-height: 150%;

--- a/src/components/ui/accordion/accordion-header.tsx
+++ b/src/components/ui/accordion/accordion-header.tsx
@@ -17,7 +17,7 @@ interface StyledIconProps {
 }
 
 const AccordionTitleHeadline = styled.span`
-  ${TextStyles.headlineXS}
+  ${TextStyles.headlineXXS}
   ${ellipsis()}
   padding-right: 20px;
   color: inherit;

--- a/src/components/ui/callout/callout.tsx
+++ b/src/components/ui/callout/callout.tsx
@@ -11,7 +11,7 @@ interface CalloutProps {
 }
 
 const CalloutLayout = styled.div`
-  ${TextStyles.headlineXS}
+  ${TextStyles.headlineXXS}
 
   padding: 16px 20px;
   color: #3e61ee;

--- a/src/components/ui/expandable/expandable.tsx
+++ b/src/components/ui/expandable/expandable.tsx
@@ -41,7 +41,7 @@ const SummaryContainer = styled.summary`
 `;
 
 const SummaryText = styled.p`
-  ${TextStyles.headlineXS}
+  ${TextStyles.headlineXXS}
   margin: 0;
   line-height: 1;
 `;

--- a/src/components/ui/image/image.tsx
+++ b/src/components/ui/image/image.tsx
@@ -56,22 +56,15 @@ const StyledLink = styled.a`
 `;
 
 const TextWrapper = styled.div<TextAlignProps>`
-  ${TextStyles.textXS}
+  ${TextStyles.textS}
 
   max-width: 100%;
   color: ${theme.palette.text.default};
 
   ${up('sm')} {
     ${({ textPlacement: textPlacement }) =>
-      textPlacement === 'bottom' &&
-      css`
-        ${TextStyles.textXS}
-      `}
-
-    ${({ textPlacement: textPlacement }) =>
       textPlacement !== 'bottom' &&
       css`
-        ${TextStyles.textS}
         max-width: 228px;
       `}
   }


### PR DESCRIPTION
### What's included?
* Fonts size changes
* New size was added (headlineXXS)

Component | Previous size (mobile - desktop) | Updated size
-- | -- | --
Hero Headline | 36 - 48 | 36 - 48
Hero Text | 18 - 22 | 18 - 22
Header Block Topline | 16 - 16 | 14 - 16
Header Block Headline | 36 - 48 | 28 - 36
HeaderBlock Text large | 22 - 22 | 16 - 18
HeaderBlock Text  | 18 - 18 | 16 - 14
TeaserTytle large | 28 - 28 | 20 - 28
TeaserTytle | 22 - 22 | 20 - 20
TeaserText | 18-18 | 18-18
ButtonText | 16-16 | 16-16
SectionHeader Kicker | 16-16 | 14-16
SectionHeader Headline | 36 - 48 | 28 - 36
SectionHeader Content | 18 - 22 | 16 - 18
Opening_SectionHeadline | 28-36 | 36 - 48
Image_TextWrapper | 12 | 14

### Preview

Desktop & Mobile 

Previous | Updated
-- | --
<img width="714" alt="Screenshot 2023-03-01 at 15 06 02" src="https://user-images.githubusercontent.com/3524642/222164589-2f07e5ff-1893-4ded-a82f-574cc90063de.png"> | <img width="720" alt="Screenshot 2023-03-01 at 15 05 50" src="https://user-images.githubusercontent.com/3524642/222163919-cb0f49aa-f7f7-4870-8c3f-af821e3d98e3.png">
<img width="266" alt="Screenshot 2023-03-01 at 15 13 54" src="https://user-images.githubusercontent.com/3524642/222165621-c59d3118-6759-448a-a1f2-c4ad8809b303.png"> | <img width="269" alt="Screenshot 2023-03-01 at 15 13 43" src="https://user-images.githubusercontent.com/3524642/222165558-2fe75cd9-3952-45f7-b375-08c42401ec52.png">  





