### PR TITLE
change number of posts per page to 8

### DIFF
--- a/gatsby/create-pages/create-blog-post-overview-pages.ts
+++ b/gatsby/create-pages/create-blog-post-overview-pages.ts
@@ -50,7 +50,7 @@ export const createBlogPostOverviewPages = async ({
   }
 
   const posts = contentfulBlogPages.data.allContentfulBlogPost.nodes;
-  const postsPerPage = 10;
+  const postsPerPage = 8;
   const numberOfPages = Math.ceil(posts.length / postsPerPage);
   Array.from({ length: numberOfPages }).forEach((_, i) => {
     createPage<BlogOverviewPageContext>({

--- a/src/components/pages/blog/posts.tsx
+++ b/src/components/pages/blog/posts.tsx
@@ -19,7 +19,7 @@ const BlogTeaserGrid = styled.div`
   // we fetch teaser of size 600px
   // this means we can search for a column size of 300px - 12px (half gap) = 288px
   // to auto fit our teasers
-  grid-template-columns: repeat(auto-fill, minmax(288px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(278px, 1fr));
 `;
 
 interface PostsProps {


### PR DESCRIPTION
### What's included?
* number of posts per page is changed to 8 (desktop version): 
- 2 rows by 4 posts (see screenshot)

![image](https://user-images.githubusercontent.com/3524642/223097026-c231cbda-2f4b-44b2-8730-b17c97ade6fb.png)

