### PR TITLE
feat(AboutUs): adjust size of team member grid

### DIFF
--- a/src/components/pages/about-us/team.tsx
+++ b/src/components/pages/about-us/team.tsx
@@ -8,15 +8,17 @@ import { SyTeamMember } from '../../../types';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 
 const TeamLayout = styled.div`
-  margin-top: 80px;
+  margin-top: 48px;
 
   display: grid;
-
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 40px 8px;
 
   ${up('sm')} {
+    margin-top: 60px;
+
     gap: 40px 24px;
+    grid-template-columns: repeat(auto-fit, minmax(256px, 1fr));
   }
 `;
 


### PR DESCRIPTION
### What's included?
* The grid columns of the team grid are larger now
* spacing adjustments

### Preview
* URL: https://satellytescomfeatmaindesignupd-featteamgrid.gatsbyjs.io/about-us/

Previous | Updated
-- | --
<img width="1236" alt="Bildschirm­foto 2023-03-07 um 15 02 26" src="https://user-images.githubusercontent.com/57712895/223444811-c4397b99-f79e-4ddd-a3b3-e9cab865fda7.png"> | <img width="1206" alt="Bildschirm­foto 2023-03-07 um 15 02 05" src="https://user-images.githubusercontent.com/57712895/223444698-7d2f7f1c-0897-4446-9e09-d921f16958f8.png">






