### PR TITLE
feat: prevent career teasers from stretching across the whole width

### DIFF
--- a/src/components/content/teaser/teaser.tsx
+++ b/src/components/content/teaser/teaser.tsx
@@ -11,7 +11,10 @@ import { Icon } from '../../ui/icon/icon';
 import { TextStyles } from '../../typography';
 import { up } from '../../support/breakpoint';
 
-const TeaserContainer = styled.div<{ hover: boolean }>`
+const TeaserContainer = styled.div<{
+  hover: boolean;
+  preventStretching?: boolean;
+}>`
   overflow: hidden;
 
   ${(props) =>
@@ -20,6 +23,16 @@ const TeaserContainer = styled.div<{ hover: boolean }>`
       color: ${theme.palette.text.topline};
       cursor: pointer;
     `};
+
+  ${up('md')} {
+    ${(props) =>
+      props.preventStretching &&
+      css`
+        &:only-child {
+          max-width: 50%;
+        }
+      `};
+  }
 `;
 
 const StyledIllustration = styled(Illustration)<{ hover: boolean }>`
@@ -120,6 +133,10 @@ export interface TeaserProps {
    * Adds a link to another page and makes the whole teaser clickable
    */
   linkTo?: string;
+  /**
+   * Prevents the teaser from stretching across the whole width if there is exactly one teaser
+   */
+  preventStretching?: boolean;
   className?: string;
   /**
    * The main text of the teaser is entered as child
@@ -155,6 +172,7 @@ export const Teaser = ({
   image,
   linkTo,
   illustration,
+  preventStretching,
   className,
   children,
 }: TeaserProps): JSX.Element => {
@@ -162,7 +180,11 @@ export const Teaser = ({
   const hasToplineContainer = Boolean(topline || dateFormatted);
 
   return (
-    <TeaserContainer className={className} hover={hoverActive}>
+    <TeaserContainer
+      className={className}
+      hover={hoverActive}
+      preventStretching={preventStretching}
+    >
       <ConditionalLink
         language={language}
         onHover={(hasHover) => setIsHoverActive(hasHover)}

--- a/src/components/pages/career/openings.tsx
+++ b/src/components/pages/career/openings.tsx
@@ -26,6 +26,16 @@ const OpeningsTeaseGrid = styled(CareerTeaserGrid)`
   }
 `;
 
+const CareerTeaser = styled(Teaser)`
+  // Prevents the teaser from stretching across the whole width
+  // if there is exactly one vacancy
+  ${up('md')} {
+    &:only-child {
+      max-width: 50%;
+    }
+  }
+`;
+
 interface OpeningsProps {
   jobs: SyPersonioJob[];
 }
@@ -38,9 +48,9 @@ export const Openings = (props: OpeningsProps) => {
       <SectionHeadline>{t('career.openings.headline')}</SectionHeadline>
       <OpeningsTeaseGrid>
         {props.jobs.map((item) => (
-          <Teaser title={item.name} linkTo={item.slug} key={item.id}>
+          <CareerTeaser title={item.name} linkTo={item.slug} key={item.id}>
             {item.short}
-          </Teaser>
+          </CareerTeaser>
         ))}
       </OpeningsTeaseGrid>
     </div>

--- a/src/components/pages/career/openings.tsx
+++ b/src/components/pages/career/openings.tsx
@@ -26,16 +26,6 @@ const OpeningsTeaseGrid = styled(CareerTeaserGrid)`
   }
 `;
 
-const CareerTeaser = styled(Teaser)`
-  // Prevents the teaser from stretching across the whole width
-  // if there is exactly one vacancy
-  ${up('md')} {
-    &:only-child {
-      max-width: 50%;
-    }
-  }
-`;
-
 interface OpeningsProps {
   jobs: SyPersonioJob[];
 }
@@ -48,9 +38,14 @@ export const Openings = (props: OpeningsProps) => {
       <SectionHeadline>{t('career.openings.headline')}</SectionHeadline>
       <OpeningsTeaseGrid>
         {props.jobs.map((item) => (
-          <CareerTeaser title={item.name} linkTo={item.slug} key={item.id}>
+          <Teaser
+            preventStretching
+            title={item.name}
+            linkTo={item.slug}
+            key={item.id}
+          >
             {item.short}
-          </CareerTeaser>
+          </Teaser>
         ))}
       </OpeningsTeaseGrid>
     </div>

--- a/src/components/pages/landingpage/career.tsx
+++ b/src/components/pages/landingpage/career.tsx
@@ -5,10 +5,22 @@ import { HomePageHeaderBlock } from './support';
 import { SyPersonioJob } from '../../../types';
 import { Button } from '../../ui/buttons/button';
 import { LandingPageTeaserGrid } from './landing-page-teaser-grid';
+import styled from 'styled-components';
+import { up } from '../../support/breakpoint';
 
 interface CareerProps {
   positions: SyPersonioJob[];
 }
+
+const CareerTeaser = styled(Teaser)`
+  // Prevents the teaser from stretching across the whole width
+  // if there is exactly one vacancy
+  ${up('md')} {
+    &:only-child {
+      max-width: 50%;
+    }
+  }
+`;
 
 const textEllipsis = (text, maxLength) => {
   const truncatedText = text.substring(0, maxLength);
@@ -34,9 +46,9 @@ export const Career = ({ positions }: CareerProps) => {
 
       <LandingPageTeaserGrid>
         {positions.map((item) => (
-          <Teaser key={item.id} title={item.name} linkTo={item.slug}>
+          <CareerTeaser key={item.id} title={item.name} linkTo={item.slug}>
             {textEllipsis(item.short, 200)}
-          </Teaser>
+          </CareerTeaser>
         ))}
       </LandingPageTeaserGrid>
       <Button to={'/career'}>{t('main.career.button')}</Button>

--- a/src/components/pages/landingpage/career.tsx
+++ b/src/components/pages/landingpage/career.tsx
@@ -5,22 +5,10 @@ import { HomePageHeaderBlock } from './support';
 import { SyPersonioJob } from '../../../types';
 import { Button } from '../../ui/buttons/button';
 import { LandingPageTeaserGrid } from './landing-page-teaser-grid';
-import styled from 'styled-components';
-import { up } from '../../support/breakpoint';
 
 interface CareerProps {
   positions: SyPersonioJob[];
 }
-
-const CareerTeaser = styled(Teaser)`
-  // Prevents the teaser from stretching across the whole width
-  // if there is exactly one vacancy
-  ${up('md')} {
-    &:only-child {
-      max-width: 50%;
-    }
-  }
-`;
 
 const textEllipsis = (text, maxLength) => {
   const truncatedText = text.substring(0, maxLength);
@@ -46,9 +34,14 @@ export const Career = ({ positions }: CareerProps) => {
 
       <LandingPageTeaserGrid>
         {positions.map((item) => (
-          <CareerTeaser key={item.id} title={item.name} linkTo={item.slug}>
+          <Teaser
+            preventStretching
+            key={item.id}
+            title={item.name}
+            linkTo={item.slug}
+          >
             {textEllipsis(item.short, 200)}
-          </CareerTeaser>
+          </Teaser>
         ))}
       </LandingPageTeaserGrid>
       <Button to={'/career'}>{t('main.career.button')}</Button>


### PR DESCRIPTION
### What's included? 
* prevent career teasers from stretching across the whole width if there is exactly one vacancy on 
  * Landing Page
  * Career Page
* `max-width: 50%`is not approved by the design team. If this should be done before the merge, then please let me know. 
* Thanks to @georgiee for spotting this edge case

### Preview
* URL: https://satellytescomfeatmaindesignupd-featcareeredgecase.gatsbyjs.io/
<img width="1303" alt="Bildschirm­foto 2023-03-07 um 17 15 23" src="https://user-images.githubusercontent.com/57712895/223483871-317b197d-c606-45e0-bdf8-5660f828db39.png">
