### PR TITLE
fix: show customer logos in Safari

### DIFF
--- a/src/components/pages/landingpage/customers.tsx
+++ b/src/components/pages/landingpage/customers.tsx
@@ -39,6 +39,11 @@ const CustomerLogoLayout = styled.div<{
   ${up('md')} {
     width: ${({ desktopWidth }) => desktopWidth}px;
   }
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 interface CustomerLogoProps {


### PR DESCRIPTION
### What was the problem?
* The customer logos on the landing page don't show up in Safari
* Broken version: https://satellytescomfeatmaindesignupd.gatsbyjs.io

<img width="583" alt="Bildschirm­foto 2023-03-07 um 18 36 07" src="https://user-images.githubusercontent.com/57712895/223503378-95b72482-08ec-4d29-94e8-7f5c10c671d1.png">


### How it is solved?
* The svg width and height is explicitly set to 100%
* Fixed version: https://satellytescomfeatmaindesignupd-fixcustomerlogos.gatsbyjs.io/
