### PR TITLE
chore: adjust spacing

### DIFF
--- a/src/components/content/header-block/header-block.tsx
+++ b/src/components/content/header-block/header-block.tsx
@@ -50,14 +50,14 @@ const Topline = styled.p`
   }
 `;
 
-const Headline = styled.h2<LargeProps>`
+const Headline = styled.h2`
   ${TextStyles.headlineM}
   letter-spacing: -0.01em;
   color: #202840;
-  margin-top: 16px;
-  margin-bottom: ${({ large }) => (large ? '32px' : '16px')};
+  margin: 12px 0 16px;
 
   ${up('md')} {
+    margin: 16px 0 24px;
     ${TextStyles.headlineL}
   }
 `;
@@ -75,13 +75,12 @@ const HeaderBlockText = styled.p<LargeProps>`
   ${up('md')} {
     ${({ large }) => (large ? TextStyles.textR : TextStyles.textSR)};
   }
-
+  margin: 16px 0 0;
   letter-spacing: -0.01em;
   color: #202840;
-  margin-top: 32px;
 
-  ${down('sm')} {
-    margin-top: 24px;
+  ${up('md')} {
+    margin: 24px 0 0;
   }
 `;
 
@@ -90,7 +89,7 @@ export const HeaderBlock = (props: HeaderBlockProps) => {
     <BlockWrapper className={props.className}>
       <TextWrapper>
         <Topline>{props.topline}</Topline>
-        <Headline large={props.large}>{props.headline}</Headline>
+        <Headline>{props.headline}</Headline>
         {props.metaline && (
           <Metaline large={props.large}>{props.metaline}</Metaline>
         )}

--- a/src/components/content/section-header/section-header.tsx
+++ b/src/components/content/section-header/section-header.tsx
@@ -33,10 +33,11 @@ const KickerStyled = styled.span`
   ${TextStyles.toplineS}
   display: block;
   color: #3e61ee;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 
   ${up('md')} {
     ${TextStyles.toplineR}
+    margin-bottom: 16px;
   }
 `;
 
@@ -44,10 +45,10 @@ const HeadlineStyled = styled.h2`
   ${TextStyles.headlineM}
   margin: 0;
   color: #202840;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 
   ${up('md')} {
-    margin-bottom: 32px;
+    margin-bottom: 24px;
     ${TextStyles.headlineL}
   }
 `;

--- a/src/components/pages/about-us/team.tsx
+++ b/src/components/pages/about-us/team.tsx
@@ -11,7 +11,7 @@ const TeamLayout = styled.div`
   margin-top: 48px;
 
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 40px 8px;
 
   ${up('sm')} {

--- a/src/components/pages/about-us/team.tsx
+++ b/src/components/pages/about-us/team.tsx
@@ -11,7 +11,7 @@ const TeamLayout = styled.div`
   margin-top: 48px;
 
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
   gap: 40px 8px;
 
   ${up('sm')} {

--- a/src/components/pages/career/application-process.tsx
+++ b/src/components/pages/career/application-process.tsx
@@ -7,7 +7,11 @@ import { TextStyles } from '../../typography';
 import { Teaser } from '../../content/teaser/teaser';
 
 const Spacer = styled.div`
-  margin-bottom: 48px;
+  margin-bottom: 32px;
+
+  ${up('md')} {
+    margin-top: 48px;
+  }
 `;
 
 const AccordionWrapper = styled.div`

--- a/src/components/pages/service/support.tsx
+++ b/src/components/pages/service/support.tsx
@@ -8,7 +8,7 @@ import { Expandable } from '../../ui/expandable/expandable';
 import { TextStyles } from '../../typography';
 import { up } from '../../support/breakpoint';
 import { WithAnchorHOC } from '../../layout/with-anchor-hoc';
-import { theme } from '../../../components/layout/theme';
+import { theme } from '../../layout/theme';
 
 export const IntroLayout = styled.div`
   ${up('md')} {
@@ -35,8 +35,12 @@ const HeadlineStyled = styled.h3`
 `;
 
 const ContentStyled = styled.div`
-  margin-top: 24px;
-  ${TextStyles.textR}
+  margin-top: 16px;
+  ${TextStyles.textR};
+
+  ${up('md')} {
+    margin-top: 24px;
+  }
 `;
 
 const Kicker = styled.span`


### PR DESCRIPTION
### What's included? 
* Spacing adjustments in different components
* Main change: The combination of kicker, headline and content now always has the same spacing (just like in Figma)
* Preview URL: https://satellytescomfeatmaindesignupd-chorespacingcleanup.gatsbyjs.io/