### PR TITLE
feat: add new list style on services page

### DIFF
--- a/src/components/pages/service/support.tsx
+++ b/src/components/pages/service/support.tsx
@@ -8,7 +8,7 @@ import { Expandable } from '../../ui/expandable/expandable';
 import { TextStyles } from '../../typography';
 import { up } from '../../support/breakpoint';
 import { WithAnchorHOC } from '../../layout/with-anchor-hoc';
-import { theme } from '../../../components/layout/theme';
+import { theme } from '../../layout/theme';
 
 export const IntroLayout = styled.div`
   ${up('md')} {
@@ -81,11 +81,11 @@ export const ExpandableStyled = styled(Expandable)`
 export const UnorderedList = styled.ul`
   line-height: 150%;
   margin: 0;
-  padding-left: 0;
+  padding-left: 12px;
   list-style-type: none;
 
   > li:before {
-    content: '-';
+    content: '•';
     position: absolute;
     top: 0;
     bottom: 0;


### PR DESCRIPTION
### What's included?
* New list style for unordered lists on services page

### Preview
* URL: https://satellytescomfeatmaindesignupd-featservicesliststyle.gatsbyjs.io/services/

Previous | Updated
-- | --
<img width="291" alt="Bildschirm­foto 2023-03-09 um 10 44 05" src="https://user-images.githubusercontent.com/57712895/223983137-da90f4b1-61f2-413b-a4bc-7e0c3b191950.png"> | <img width="314" alt="Bildschirm­foto 2023-03-09 um 10 45 28" src="https://user-images.githubusercontent.com/57712895/223983487-382f44cb-45da-46a8-9875-511b019ef246.png">





