### PR TITLE
feat: add new illustrations to the pages

### DIFF
--- a/src/components/pages/career/culture.tsx
+++ b/src/components/pages/career/culture.tsx
@@ -17,48 +17,48 @@ const ASPECTS = (t): CultureAspect[] => [
   {
     title: t('career.culture.teaser.0.title'),
     description: t('career.culture.teaser.0.description'),
-    illustration: 'uranus_050',
+    illustration: 'positiveWork_060',
   },
 
   {
     title: t('career.culture.teaser.1.title'),
     description: t('career.culture.teaser.1.description'),
-    illustration: 'stars_009',
+    illustration: 'communication_061',
   },
 
   {
     title: t('career.culture.teaser.2.title'),
     description: t('career.culture.teaser.2.description'),
-    illustration: 'agile_059',
+    illustration: 'appreciate_063',
   },
 
   {
     title: t('career.culture.teaser.3.title'),
     description: t('career.culture.teaser.3.description'),
-    illustration: 'planets_005',
+    illustration: 'workLifeBalance_064',
   },
 
   {
     title: t('career.culture.teaser.4.title'),
     description: t('career.culture.teaser.4.description'),
-    illustration: 'report_031',
+    illustration: 'events_062',
   },
   {
     title: t('career.culture.teaser.5.title'),
     description: t('career.culture.teaser.5.description'),
-    illustration: 'blimp_000',
+    illustration: 'teamwork_067',
   },
 
   {
     title: t('career.culture.teaser.6.title'),
     description: t('career.culture.teaser.6.description'),
-    illustration: 'report_031',
+    illustration: 'selfOrganization_066',
   },
 
   {
     title: t('career.culture.teaser.7.title'),
     description: t('career.culture.teaser.7.description'),
-    illustration: 'blimp_000',
+    illustration: 'crossfunction_065',
   },
 ];
 

--- a/src/components/pages/career/perks.tsx
+++ b/src/components/pages/career/perks.tsx
@@ -23,7 +23,7 @@ const PERKS = (t): Perk[] => [
   {
     title: t('career.perk.teaser.1.title'),
     description: t('career.perk.teaser.1.description'),
-    illustration: 'scientistA_006',
+    illustration: 'planetarium_028',
   },
 
   {
@@ -47,19 +47,19 @@ const PERKS = (t): Perk[] => [
   {
     title: t('career.perk.teaser.5.title'),
     description: t('career.perk.teaser.5.description'),
-    illustration: 'planetarium_028',
+    illustration: 'solar_system_040',
   },
 
   {
     title: t('career.perk.teaser.6.title'),
     description: t('career.perk.teaser.6.description'),
-    illustration: 'galaxy_013',
+    illustration: 'flag_041',
   },
 
   {
     title: t('career.perk.teaser.7.title'),
     description: t('career.perk.teaser.7.description'),
-    illustration: 'planetarium_028',
+    illustration: 'scientistA_006',
   },
 ];
 


### PR DESCRIPTION
### What's included?
* The illustrations are added to their corresponding places in the code

### Preview
* https://satellytescomfeatmaindesignupd-featplaceillustrations.gatsbyjs.io/de/
<img width="1203" alt="Bildschirm­foto 2023-03-09 um 13 59 52" src="https://user-images.githubusercontent.com/57712895/224030918-17df550e-b3b2-4366-a9f4-be315363b5c5.png">



