### PR TITLE
fix: prevent content from being cut off on anchor tag scrolling

### DIFF
--- a/src/components/layout/use-anchor-tag-scrolling.ts
+++ b/src/components/layout/use-anchor-tag-scrolling.ts
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
-import { HEADER_HEIGHT } from './header/header';
+import { HEADER_HEIGHT_VALUE } from './theme';
+
+// we need to scroll past the header and a little offset
+export const SCROLLING_OFFSET = HEADER_HEIGHT_VALUE + 50;
 
 export const useAnchorTagScrolling = (): void => {
   useEffect(() => {
@@ -19,10 +22,7 @@ export const scrollToTarget = (target: Element | null) => {
   }
 
   const scrollTop =
-    target.getBoundingClientRect().top +
-    window.pageYOffset -
-    // we need to scroll past the header and a little offset
-    (Number.parseInt(HEADER_HEIGHT, 10) + 16);
+    target.getBoundingClientRect().top + window.pageYOffset - SCROLLING_OFFSET;
 
   window.scrollTo({
     top: scrollTop,

--- a/src/components/layout/with-anchor-hoc.tsx
+++ b/src/components/layout/with-anchor-hoc.tsx
@@ -3,7 +3,8 @@ import React, { useState } from 'react';
 import { onlyText } from '../support/only-text';
 import { Icon } from '../ui/icon/icon';
 import { up } from '../support/breakpoint';
-import { HEADER_HEIGHT_VALUE, theme } from './theme';
+import { theme } from './theme';
+import { SCROLLING_OFFSET } from './use-anchor-tag-scrolling';
 
 const Wrapper = styled.div`
   margin-left: -24px;
@@ -22,7 +23,7 @@ export const generateAnchorId = (children) => {
 };
 
 const ShareSymbol = styled.a<{ visible }>`
-  scroll-margin-top: ${HEADER_HEIGHT_VALUE + 20}px;
+  scroll-margin-top: ${SCROLLING_OFFSET}px;
   color: ${theme.palette.text.default};
   opacity: 0.3;
 


### PR DESCRIPTION
### What's included?
* The upper offset for anchor tag scrolling has been increased so that the content is not cut off

### Preview:
* URL: https://satellytescomfeatmaindesignupd-fixanchorscrolling.gatsbyjs.io/de/services/#technische-beratung

| Before | Updated |
| ----------- | ----------- |
| <img width="1029" alt="Bildschirm­foto 2023-03-14 um 10 11 43" src="https://user-images.githubusercontent.com/57712895/224952984-f72879d0-e136-44a1-91e1-dd9fb86e5ec8.png"> | <img width="1031" alt="Bildschirm­foto 2023-03-14 um 10 13 39" src="https://user-images.githubusercontent.com/57712895/224953186-8be79a24-18ff-4691-865c-70b473b63800.png"> |
| <img width="1021" alt="Bildschirm­foto 2023-03-14 um 10 14 10" src="https://user-images.githubusercontent.com/57712895/224953309-95388d43-8512-416d-9085-cb15e8edf621.png"> | <img width="1029" alt="Bildschirm­foto 2023-03-14 um 10 14 17" src="https://user-images.githubusercontent.com/57712895/224953356-63f94ab9-86f9-4243-9d7e-b7ae86ee4bae.png"> |