### PR TITLE
feat: show hero text on different positions

### DIFF
--- a/src/components/content/heroes/aurora-hero.tsx
+++ b/src/components/content/heroes/aurora-hero.tsx
@@ -14,6 +14,7 @@ interface AuroraHeroProps extends HeroWithText {
 
 export const AuroraHero = ({
   title,
+  hideMobileText,
   children,
   auroraType,
 }: AuroraHeroProps) => {
@@ -22,7 +23,9 @@ export const AuroraHero = ({
       <AuroraFullSize type={auroraType} />
 
       <TextContainer>
-        <HeroText title={title}>{children}</HeroText>
+        <HeroText hideMobileText={hideMobileText} title={title}>
+          {children}
+        </HeroText>
       </TextContainer>
     </HeroContainer>
   );

--- a/src/components/content/heroes/blog-hero.tsx
+++ b/src/components/content/heroes/blog-hero.tsx
@@ -53,6 +53,7 @@ const Attribution = ({ attribution }: { attribution?: BlogAttribution }) => {
 export const BlogHero = ({
   image,
   attribution,
+  hideMobileText,
   title,
   children,
   naturalHeight,
@@ -67,7 +68,9 @@ export const BlogHero = ({
 
       {title && (
         <TextContainer dimmed>
-          <HeroText title={title}>{children}</HeroText>
+          <HeroText hideMobileText={hideMobileText} title={title}>
+            {children}
+          </HeroText>
         </TextContainer>
       )}
 

--- a/src/components/content/heroes/hero-text.tsx
+++ b/src/components/content/heroes/hero-text.tsx
@@ -1,19 +1,20 @@
-import styled from 'styled-components';
-import { up } from '../../support/breakpoint';
+import styled, { css } from 'styled-components';
+import { down, up } from '../../support/breakpoint';
 import { TextStyles } from '../../typography';
 import React from 'react';
 import { ReactNode } from 'react';
 
 export interface HeroWithText {
   title: string;
+  hideMobileText?: boolean;
   children?: ReactNode;
 }
 
-export const HeroText = ({ title, children }: HeroWithText) => {
+export const HeroText = ({ title, children, hideMobileText }: HeroWithText) => {
   return (
     <HeroTextStyled>
       <Headline>{title}</Headline>
-      <Text>{children}</Text>
+      <Text hideMobileText={hideMobileText}>{children}</Text>
     </HeroTextStyled>
   );
 };
@@ -38,10 +39,18 @@ const Headline = styled.h1`
   }
 `;
 
-const Text = styled.div`
+const Text = styled.div<{ hideMobileText?: boolean }>`
   ${TextStyles.textR}
 
   ${up('md')} {
     ${TextStyles.textL}
   }
+
+  ${({ hideMobileText }) =>
+    hideMobileText &&
+    css`
+      ${down('md')} {
+        display: none;
+      }
+    `}
 `;

--- a/src/components/content/heroes/image-hero.tsx
+++ b/src/components/content/heroes/image-hero.tsx
@@ -19,7 +19,12 @@ type ImageHeroProps = Partial<HeroWithText> & {
 /**
  * Display any given gatsby image as a hero image.
  */
-export const ImageHero = ({ image, title, children }: ImageHeroProps) => {
+export const ImageHero = ({
+  image,
+  title,
+  hideMobileText,
+  children,
+}: ImageHeroProps) => {
   const gatsbyImageData = getImage(image);
 
   return (
@@ -30,7 +35,9 @@ export const ImageHero = ({ image, title, children }: ImageHeroProps) => {
 
       {title && (
         <TextContainer dimmed>
-          <HeroText title={title}>{children}</HeroText>
+          <HeroText hideMobileText={hideMobileText} title={title}>
+            {children}
+          </HeroText>
         </TextContainer>
       )}
     </HeroContainer>

--- a/src/components/content/heroes/support.tsx
+++ b/src/components/content/heroes/support.tsx
@@ -61,3 +61,8 @@ export const TextContainer = styled.div<TextContainerProps>`
       background-color: ${rgba('#000000', 0.2)};
     `}
 `;
+export const MobileOnlyText = styled.p`
+  ${up('md')} {
+    display: none;
+  }
+`;

--- a/src/components/pages/about-us/about-us-page.tsx
+++ b/src/components/pages/about-us/about-us-page.tsx
@@ -34,6 +34,7 @@ export const AboutUsPage = (props: AboutUsPageProps) => {
       leadbox={leadbox}
       hero={
         <ImageHero
+          hideMobileText
           title={t<string>('about-us.title')}
           image={props.heroImageData}
         >

--- a/src/components/pages/about-us/impressions.tsx
+++ b/src/components/pages/about-us/impressions.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import styled from 'styled-components';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { up } from '../../support/breakpoint';
+import { MobileOnlyText } from '../../content/heroes/support';
 
 interface ImpressionsProps {
   impressions: ContentfulAboutUsImpression[];
@@ -57,6 +58,7 @@ export const Impressions = ({ impressions }: ImpressionsProps) => {
         headline={t<string>('about-us.impressions.heading')}
         kicker={t<string>('about-us.impressions.title')}
       >
+        <MobileOnlyText>{t('about-us.description')}</MobileOnlyText>
         {t('about-us.impressions.text')}
       </SectionHeader>
 

--- a/src/components/pages/career/career-page.tsx
+++ b/src/components/pages/career/career-page.tsx
@@ -13,6 +13,7 @@ import { ImageHero } from '../../content/heroes';
 import { IGatsbyImageData } from 'gatsby-plugin-image';
 import { ImageSpacer } from '../../ui/image/image-spacer';
 import { OfficeImage } from '../../../pages';
+import { MobileOnlyText } from '../../content/heroes/support';
 
 interface CareerPageProps {
   positions: SyPersonioJob[];
@@ -45,7 +46,11 @@ export const CareerPage = ({
       transparentHeader={true}
       light={true}
       hero={
-        <ImageHero title={t<string>('career.title')} image={heroImageData}>
+        <ImageHero
+          hideMobileText
+          title={t<string>('career.title')}
+          image={heroImageData}
+        >
           {' '}
           {t('career.description')}{' '}
         </ImageHero>
@@ -57,6 +62,7 @@ export const CareerPage = ({
           kicker={t<string>('career.introduction.kicker')}
           headline={t<string>('career.introduction.headline')}
         >
+          <MobileOnlyText>{t('career.description')}</MobileOnlyText>
           {t('career.introduction.paragraphs.0')}
         </SectionHeader>
         <ApplicationProcess />


### PR DESCRIPTION
### What's included?
* There is a new requirement for the Hero Text on the Career and About-Us page: The text in the Hero shouldn't be displayed in the Hero on mobile, but under the first heading.
* To hide the text in the hero, a flag `hideMobileText` was added to the hero
* In addition, there is an `MobileOnlyText` component that can be added under the corresponding headlines

### Preview
* URL: https://satellytescomfeatmaindesignupd-featherotext.gatsbyjs.io/de/career/
<img width="1457" alt="Bildschirm­foto 2023-03-14 um 14 04 48" src="https://user-images.githubusercontent.com/57712895/225010017-2a6b964f-b802-471d-b9ed-2ecae24be997.png">
