### PR TITLE
fix: make filed-dropper clickable in firefox

### DIFF
--- a/src/components/forms/file-dropper/file-dropper.tsx
+++ b/src/components/forms/file-dropper/file-dropper.tsx
@@ -195,7 +195,6 @@ export const FileDropper = ({
     validator,
     onDropRejected,
     maxFiles,
-    useFsAccessApi: true,
   });
 
   const hasFiles = Boolean(currentFiles.length);

--- a/src/components/forms/file-dropper/file-dropper.tsx
+++ b/src/components/forms/file-dropper/file-dropper.tsx
@@ -76,6 +76,7 @@ const FileDropperContainer = styled.div<{
   hasFiles: boolean;
   hasErrors: boolean;
 }>`
+  position: relative;
   display: flex;
   gap: 16px;
   flex-direction: column;
@@ -109,6 +110,15 @@ const FileDropperContainer = styled.div<{
   &:hover {
     border: 1px solid ${theme.palette.text.default};
   }
+`;
+
+const StyledLabel = styled.label`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  cursor: pointer;
 `;
 
 const Description = styled.p`
@@ -184,6 +194,7 @@ export const FileDropper = ({
     validator,
     onDropRejected,
     maxFiles,
+    useFsAccessApi: true,
   });
 
   const hasFiles = Boolean(currentFiles.length);
@@ -197,7 +208,9 @@ export const FileDropper = ({
         hasFiles={hasFiles}
         hasErrors={errors?.documents}
       >
-        <input {...getInputProps({ ...register(name) })} />
+        <StyledLabel>
+          <input {...getInputProps({ ...register(name) })} />
+        </StyledLabel>
         {!hasFiles && illustration && (
           <Illustration show={illustration} size={IllustrationSize.NORMAL} />
         )}

--- a/src/components/forms/file-dropper/file-dropper.tsx
+++ b/src/components/forms/file-dropper/file-dropper.tsx
@@ -112,6 +112,7 @@ const FileDropperContainer = styled.div<{
   }
 `;
 
+// Without the label the FileDropper is not clickable in Firefox
 const StyledLabel = styled.label`
   width: 100%;
   height: 100%;

--- a/src/components/forms/file-dropper/file-list-item.tsx
+++ b/src/components/forms/file-dropper/file-list-item.tsx
@@ -104,7 +104,7 @@ export const FileListItem = ({
             ))}
           </FileCategoryDropdown>
         )}
-        <RemoveButton onClick={() => onRemove(index)}>
+        <RemoveButton type="button" onClick={() => onRemove(index)}>
           {t('career.remove-file')}
         </RemoveButton>
       </Actions>


### PR DESCRIPTION
### What was the problem?
* The file dropper wasn't clickable in Firefox (only drop worked)

### How it is solved?
* By adding a label inside the container the file dropper is also clickable in Firefox

Preview URL: https://satellytescommain21751-fixfiledropper.gatsbyjs.io/career/senior-ux-ui-designer/