### PR TITLE
chore(CareerPage): remove second h1

### DIFF
--- a/src/components/pages/career/career-page.tsx
+++ b/src/components/pages/career/career-page.tsx
@@ -58,7 +58,6 @@ export const CareerPage = ({
     >
       <ContentBlockContainer>
         <SectionHeader
-          as={'h1'}
           kicker={t<string>('career.introduction.kicker')}
           headline={t<string>('career.introduction.headline')}
         >


### PR DESCRIPTION
The "Arbeite mit uns" headline on the careers page is now an h2 instead of h1. This way there is only one h1 on each page and all pages have the same structure.

URL: https://satellytescomfeatmaindesignupd-chorecareerheaders.gatsbyjs.io/de/career/