### PR TITLE
fix(RSS): show blog article hero images on dev.to

### DIFF
--- a/gatsby/config-options/gatsby-plugin-feed-options.tsx
+++ b/gatsby/config-options/gatsby-plugin-feed-options.tsx
@@ -202,9 +202,8 @@ const feedOptions = {
     {
       serialize: ({ query: { site, allContentfulBlogPost } }) => {
         return allContentfulBlogPost.nodes.map((node) => {
-          const imageUrl = `${BASE_URL}${
-            node.heroImage.image?.resize?.src ?? DEFAULT_META_IMAGE_URL_PATH
-          }`;
+          const imageUrl = node.heroImage.image?.url;
+
           const coverImage =
             node.heroImage && node.heroImage.creator
               ? toHtml(
@@ -372,9 +371,6 @@ const feedOptions = {
                 heroImage {
                   image {
                     url
-                    resize(width: 1440, height: 760) {
-                      src
-                    }
                   }
                   creator
                   source


### PR DESCRIPTION
### What was the problem?
* We use our RSS feed to sync the blog articles with dev.to. All assets are displayed correctly except the hero images:
<img width="780" alt="Bildschirm­foto 2023-03-21 um 16 23 49" src="https://user-images.githubusercontent.com/57712895/226655084-83d0489d-3686-4ca5-b42e-d02c398d097a.png">

### How it is solved?
* The image is now provided directly by contentful (without resize). The image is then displayed in dev.to before the actual content. To display it on dev.to as a cover image, the URL of the image must be manually added to the `cover_image` entry. I have tried several ways to load the image directly from the RSS as cover_image. Unfortunately without success. I think as long as dev.to does not implement this function, we have no influence on it.


### How to test?
* Currently the feature branch is not connected to our technical user on dev.to. To test the changes, you can connect your own dev.to account to the RSS feed. I have added the changes to one article from the technical user as a test and the image is displayed correctly now: https://dev.to/technicalusersatellytes/a-semantic-approach-to-buttons-more-2l1c-temp-slug-2550192?preview=0311b025c182bc4a976683d85cc49e485327d72073463e2f7610afd46b607d8647c80447eed6cdd6b57831c09da25e50e75e0fb67203a042d98a84ca
* To display the image as a cover image, you have to add the URL to the cover_image field as said before:
<img width="1795" alt="Bildschirm­foto 2023-03-21 um 16 51 50" src="https://user-images.githubusercontent.com/57712895/226665380-bae68cc4-c1ac-4b52-9521-7ab286666558.png">

