### PR TITLE
chore: typography adjustments

### DIFF
--- a/src/components/content/section-header/section-header.tsx
+++ b/src/components/content/section-header/section-header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { TextStyles } from '../../typography';
 import { up } from '../../support/breakpoint';
 
@@ -26,6 +26,10 @@ interface SectionHeaderProps {
    * The actual text content
    */
   children?: React.ReactNode;
+  /**
+   * Large headline
+   */
+  large?: boolean;
   className?: string;
 }
 
@@ -41,7 +45,7 @@ const KickerStyled = styled.span`
   }
 `;
 
-const HeadlineStyled = styled.h2`
+const HeadlineStyled = styled.h2<{ large?: boolean }>`
   ${TextStyles.headlineM}
   margin: 0;
   color: #202840;
@@ -51,6 +55,15 @@ const HeadlineStyled = styled.h2`
     margin-bottom: 24px;
     ${TextStyles.headlineL}
   }
+
+  ${({ large }) =>
+    large &&
+    css`
+      ${TextStyles.headlineL}
+      ${up('md')} {
+        ${TextStyles.headlineXL}
+      }
+    `}
 `;
 
 const ContentStyled = styled.div`
@@ -67,7 +80,9 @@ export const SectionHeader = (props: SectionHeaderProps) => {
       {props.kicker && (
         <KickerStyled as={props.kickerAs}>{props.kicker}</KickerStyled>
       )}
-      <HeadlineStyled as={props.as}>{props.headline}</HeadlineStyled>
+      <HeadlineStyled large={props.large} as={props.as}>
+        {props.headline}
+      </HeadlineStyled>
       <ContentStyled>{props.children}</ContentStyled>
     </div>
   );

--- a/src/components/pages/career-details/career-details.tsx
+++ b/src/components/pages/career-details/career-details.tsx
@@ -48,6 +48,7 @@ export const CareerDetails = ({
     >
       <StyledContentBlockContainer>
         <SectionHeader
+          large
           as={'h1'}
           headline={position.name}
           kicker={t<string>('career.position')}

--- a/src/pages/data-privacy.tsx
+++ b/src/pages/data-privacy.tsx
@@ -27,7 +27,11 @@ const DataPrivacyPage = ({
         noIndex={true}
       />
       <ContentBlockContainer>
-        <SectionHeader as={'h1'} headline={t('navigation.data-privacy')} />
+        <SectionHeader
+          large
+          as={'h1'}
+          headline={t('navigation.data-privacy')}
+        />
         <MarkdownAst htmlAst={data.markdownRemark.htmlAst} />
       </ContentBlockContainer>
     </Layout>

--- a/src/pages/imprint.tsx
+++ b/src/pages/imprint.tsx
@@ -7,11 +7,9 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { Layout } from '../components/layout/layout';
 import { SectionHeader } from '../components/content/section-header/section-header';
 import { ContentBlockContainer } from '../components/layout/content-block-container';
-import { TextStyles } from '../components/typography';
+import { Text } from '../components/legacy/typography';
 
-const BottomNote = styled.p`
-  ${TextStyles.textR}
-
+const BottomNote = styled(Text)`
   margin-top: 80px;
   margin-bottom: 16px;
   opacity: 0.8;
@@ -34,7 +32,7 @@ const ImprintPage = ({ data, location }: PageProps<ImprintPageQueryProps>) => {
         noIndex={true}
       />
       <ContentBlockContainer>
-        <SectionHeader as={'h1'} headline={t('navigation.imprint')} />
+        <SectionHeader large as={'h1'} headline={t('navigation.imprint')} />
         <MarkdownAst htmlAst={data.markdownRemark.htmlAst} />
         <BottomNote>{t('imprint.updated')}</BottomNote>
       </ContentBlockContainer>


### PR DESCRIPTION
### What's included?

* Increased font sizes for data privacy and imprint headlines:

<img width="1417" alt="Bildschirm­foto 2023-03-23 um 09 57 35" src="https://user-images.githubusercontent.com/57712895/227156715-1732f1ca-df81-4cac-8c03-14fc69b20adc.png">

---
* Updated font size for imprint timestamp:

<img width="1417" alt="Bildschirm­foto 2023-03-23 um 09 57 20" src="https://user-images.githubusercontent.com/57712895/227156730-f5a59ca9-9992-4ba7-8e7d-55cd6cb36b95.png">

---
* Increased font sizes for vacancy headlines:

<img width="1423" alt="Bildschirm­foto 2023-03-23 um 09 55 45" src="https://user-images.githubusercontent.com/57712895/227156740-36b235e6-3ede-4737-8ca2-f0dafa1f93d2.png">

### Preview
* Imprint: https://satellytescomfeatmaindesignupd-choretypography.gatsbyjs.io/de/imprint/
* Data privacy: https://satellytescomfeatmaindesignupd-choretypography.gatsbyjs.io/de/data-privacy/
* Vacancy: https://satellytescomfeatmaindesignupd-choretypography.gatsbyjs.io/de/career/senior-ux-ui-designer/