### PR TITLE
fix(career): provide correct channel id to post messages

### DIFF
--- a/src/api/career-form.ts
+++ b/src/api/career-form.ts
@@ -2,7 +2,7 @@ import { GatsbyFunctionRequest, GatsbyFunctionResponse } from 'gatsby';
 import { LogLevel, WebClient } from '@slack/web-api';
 
 const TOKEN = process.env.SLACK_BOT_SY_TOKEN;
-const CHANNEL_ID = 'raketenhafte-rekrutierung';
+const CHANNEL_ID = 'C04TU7RUEM8'; // id of the recruiting channel
 
 const getFileNameList = (files) =>
   files?.reduce((acc, current) => acc + ` - ${current.originalname} \n`, '');


### PR DESCRIPTION
I renamed our internal channel and did not update the channel id. I've now included the internal channel id number and not the channel name to make it more robust. I will submit the form on the feature deployment.