### PR TITLE
fix: career form slack message fields

### DIFF
--- a/src/api/career-form.ts
+++ b/src/api/career-form.ts
@@ -52,7 +52,7 @@ const createSlackMessage = ({
         {
           type: 'mrkdwn',
           text: `*Avaible from*:\n ${
-            available_from === 'undefined' ? '-' : salary_expectations
+            available_from === 'undefined' ? '-' : available_from
           }`,
         },
         {


### PR DESCRIPTION
### Changes

This PR fixes a small bug inside the career form slack message submission. We sent the `salary_expectation` where the `available_from` should be.