### PR TITLE
fix: use correct graphql query for blog article leadbox links

### DIFF
--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -104,10 +104,9 @@ export const BlogPostPageQuery = graphql`
     ) {
       title
       illustration
-      contact {
-        headline
+      link {
         title
-        email
+        href
       }
     }
 


### PR DESCRIPTION
Closes #773 

### What was the problem? 
* The links in the leadbox of a blog article page are empty and not working (s. screenshot) 
![Bildschirmfoto 2023-09-12 um 09 52 12](https://github.com/satellytes/satellytes.com/assets/57712895/264792ec-b85f-4012-9be8-21f4978ba3b6)
(https://satellytes.com/blog/post/monorepo-the-right-fit-for-your-project/)

### How it is solved?
* The corresponding GraphQL query now uses `link` instead of `contact`
* Preview URL: https://satellytescommain21751-fixblogleadboxlinks.gatsbyjs.io/blog/post/monorepo-the-right-fit-for-your-project/
