### PR TITLE
fix: add missing translation keys

### DIFF
--- a/src/assets/locales/de/translations.json
+++ b/src/assets/locales/de/translations.json
@@ -4,6 +4,7 @@
   "main.blog.button": "Alle Artikel",
   "main.services.button": "Erfahren Sie mehr",
   "career.mandatory-field": "* Pflichtfeld",
+  "career.headline": "Bewirb dich jetzt!",
   "career.first-name": "Vorname",
   "career.last-name": "Nachname",
   "career.email": "E-Mail Adresse",

--- a/src/assets/locales/en/translations.json
+++ b/src/assets/locales/en/translations.json
@@ -3,6 +3,7 @@
   "main.career.button": "All vacancies",
   "main.blog.button": "All articles",
   "main.services.button": "Learn more",
+  "career.headline": "Applx now!",
   "career.mandatory-field": "* Mandatory field",
   "career.first-name": "First name",
   "career.last-name": "Last name",

--- a/src/assets/locales/en/translations.json
+++ b/src/assets/locales/en/translations.json
@@ -3,7 +3,7 @@
   "main.career.button": "All vacancies",
   "main.blog.button": "All articles",
   "main.services.button": "Learn more",
-  "career.headline": "Applx now!",
+  "career.headline": "Apply now!",
   "career.mandatory-field": "* Mandatory field",
   "career.first-name": "First name",
   "career.last-name": "Last name",


### PR DESCRIPTION
### What has been done?

We lost some translation keys during the redesign of the website.

![image](https://github.com/satellytes/satellytes.com/assets/78978542/aa0435f9-d60e-4bb3-9c74-1e255cadc46f)

### How to verify?

- https://deploy-preview-780--satellytes.netlify.app/career/staff-software-engineer/
- https://deploy-preview-780--satellytes.netlify.app/de/career/staff-software-engineer/