### PR TITLE
fix (a11y): breadcrumb a11y issues on blog page

### DIFF
--- a/src/components/layout/breadcrumb/breadcrumb.tsx
+++ b/src/components/layout/breadcrumb/breadcrumb.tsx
@@ -8,7 +8,9 @@ const BreadcrumbContainer = styled.ol`
   list-style: none;
   display: flex;
   flex-wrap: nowrap;
-  padding: 0;
+  overflow-x: clip;
+  padding-left: 4px;
+  transform: translateX(-4px);
 `;
 
 const BreadcrumbListItem = styled.li`
@@ -31,6 +33,10 @@ const BreadcrumbListItem = styled.li`
   }
 `;
 
+const BreadcrumbLink = styled(Link)`
+  display: inline-block;
+`;
+
 interface BreadcrumbProps {
   breadcrumbEntries: BreadcrumbEntry[];
 }
@@ -49,7 +55,9 @@ export const Breadcrumb = ({
         {breadcrumbEntries.map((breadcrumbEntry) => {
           return (
             <BreadcrumbListItem key={breadcrumbEntry.label}>
-              <Link to={breadcrumbEntry.pathname}>{breadcrumbEntry.label}</Link>
+              <BreadcrumbLink to={breadcrumbEntry.pathname}>
+                {breadcrumbEntry.label}
+              </BreadcrumbLink>
             </BreadcrumbListItem>
           );
         })}

--- a/src/components/layout/breadcrumb/breadcrumb.tsx
+++ b/src/components/layout/breadcrumb/breadcrumb.tsx
@@ -8,7 +8,6 @@ const BreadcrumbContainer = styled.ol`
   list-style: none;
   display: flex;
   flex-wrap: nowrap;
-  overflow: hidden;
   padding: 0;
 `;
 
@@ -45,7 +44,7 @@ export const Breadcrumb = ({
   breadcrumbEntries,
 }: BreadcrumbProps): JSX.Element => {
   return (
-    <BreadcrumbContainer>
+    <BreadcrumbContainer aria-label="breadcumbs" role="navigation">
       {breadcrumbEntries.map((breadcrumbEntry) => {
         return (
           <BreadcrumbListItem key={breadcrumbEntry.label}>

--- a/src/components/layout/breadcrumb/breadcrumb.tsx
+++ b/src/components/layout/breadcrumb/breadcrumb.tsx
@@ -44,14 +44,16 @@ export const Breadcrumb = ({
   breadcrumbEntries,
 }: BreadcrumbProps): JSX.Element => {
   return (
-    <BreadcrumbContainer aria-label="breadcumbs" role="navigation">
-      {breadcrumbEntries.map((breadcrumbEntry) => {
-        return (
-          <BreadcrumbListItem key={breadcrumbEntry.label}>
-            <Link to={breadcrumbEntry.pathname}>{breadcrumbEntry.label}</Link>
-          </BreadcrumbListItem>
-        );
-      })}
-    </BreadcrumbContainer>
+    <nav aria-label="breadcrumbs">
+      <BreadcrumbContainer aria-label="breadcumbs">
+        {breadcrumbEntries.map((breadcrumbEntry) => {
+          return (
+            <BreadcrumbListItem key={breadcrumbEntry.label}>
+              <Link to={breadcrumbEntry.pathname}>{breadcrumbEntry.label}</Link>
+            </BreadcrumbListItem>
+          );
+        })}
+      </BreadcrumbContainer>
+    </nav>
   );
 };

--- a/src/components/layout/theme.tsx
+++ b/src/components/layout/theme.tsx
@@ -25,7 +25,7 @@ export const theme: DefaultTheme = {
         light: '#3E61EE',
         hover: '#202840',
       },
-      breadcrumb: 'rgba(0, 0, 0, 0.5)',
+      breadcrumb: 'rgba(0, 0, 0, 0.65)',
       link: {
         default: '#3E61EE',
         hover: '#4D79FF',


### PR DESCRIPTION
Chages: 
- change breadcrumb text color from rgb(0, 0, 0, 0.5) to rgb(0, 0, 0, 0.65) to make color contrast WCAG AA compliant 
- add aria-label to breadcrumb container
- wrap breadcrumb container with nav landmark
- replace `overflow: hidden` with `overflow-x: clip` to only hide the overflow in the x direction
- replace `padding: 0` with `padding-left: 4px` so the outline isn't cut of at the left side
- add `transform: translateX(-4px)` to breadcrumb container to counteract the visual changes through the padding change
- add `display: inline-block` to the breadcrumb link to fix the shape of the focus outline   
 
 
Before: 
![image](https://github.com/user-attachments/assets/46a7393c-75c3-47de-8236-6abc6544215f)
After (without `display: inline-block` added ):
![image](https://github.com/user-attachments/assets/52bf05cf-bee6-4515-a420-4376ef0d74c5)
