### PR TITLE
fix (a11y): social link focus outline

### DIFF
--- a/src/components/layout/navigation/navigation.tsx
+++ b/src/components/layout/navigation/navigation.tsx
@@ -84,6 +84,8 @@ const SocialLink = styled.a`
   svg {
     vertical-align: middle;
   }
+
+  display: inline-block;
 `;
 
 const LegalLink = styled(Link)<{ $isSelected: boolean }>`


### PR DESCRIPTION
Changes: 
- added `display: inline-block` to SocialLink to fix the issue that the focus ouline around social links was invisible 

Before:
![image](https://github.com/user-attachments/assets/eb2b7dd7-ccc8-4136-aa27-f62252dd7eaa)

After:
![image](https://github.com/user-attachments/assets/920211da-f04f-4fe9-962f-6efb880dd343)
