### PR TITLE
fix (a11y): add aria hidden to navigation flyout when visually hidden

### DIFF
--- a/src/components/layout/header/menu-flyout.tsx
+++ b/src/components/layout/header/menu-flyout.tsx
@@ -81,7 +81,6 @@ export const NavigationFlyout: React.FC<NavigationFlyoutProp> = (props) => {
       <BackgroundOverlay
         $visible={props.visible}
         onClick={() => props.setIsNavigationVisible(false)}
-        aria-hidden={!props.visible}
       />
     </>
   );

--- a/src/components/layout/header/menu-flyout.tsx
+++ b/src/components/layout/header/menu-flyout.tsx
@@ -65,7 +65,11 @@ interface NavigationFlyoutProp {
 export const NavigationFlyout: React.FC<NavigationFlyoutProp> = (props) => {
   return (
     <>
-      <FullscreenOverlay $visible={props.visible} onClick={props.onClick}>
+      <FullscreenOverlay
+        $visible={props.visible}
+        onClick={props.onClick}
+        aria-hidden={!props.visible}
+      >
         <ScrollContainer>
           <FullHeightNavigation
             translation={props.translation}
@@ -77,6 +81,7 @@ export const NavigationFlyout: React.FC<NavigationFlyoutProp> = (props) => {
       <BackgroundOverlay
         $visible={props.visible}
         onClick={() => props.setIsNavigationVisible(false)}
+        aria-hidden={!props.visible}
       />
     </>
   );


### PR DESCRIPTION
Changes: 
- add `aria-hidden={!props.visible}` to FullscreenOverlay