### PR TITLE
Fix: Change slack file upload method to uploadV2

### DIFF
--- a/src/api/career-form.ts
+++ b/src/api/career-form.ts
@@ -148,7 +148,7 @@ export default async function handler(
     });
 
     for (const file of files) {
-      await client.files.upload({
+      await client.files.uploadV2({
         channels: CHANNEL_ID,
         thread_ts: postMessageResult.ts,
         file: file.buffer,


### PR DESCRIPTION
# Change:
- use the new `uploadV2` method instead of the `upload` method 

https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay#prepare