### PR TITLE
fix: global navigation close/open button

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "prettier \"**/*.{tsx,ts,md}\" --write",
     "test:types": "tsc --noEmit",
     "test:lint": "eslint \"**/*.{tsx,ts}\"",
-    "test:format": "prettier \"**/*.{tsx,ts,md}\" --check --debug-check",
+    "test:format": "prettier \"**/*.{tsx,ts,md}\" --check",
     "postinstall": "husky install",
     "precommit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "prettier \"**/*.{tsx,ts,md}\" --write",
     "test:types": "tsc --noEmit",
     "test:lint": "eslint \"**/*.{tsx,ts}\"",
-    "test:format": "prettier \"**/*.{tsx,ts,md}\" --check --log-level=debug",
+    "test:format": "prettier \"**/*.{tsx,ts,md}\" --check --debug-check",
     "postinstall": "husky install",
     "precommit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "prettier \"**/*.{tsx,ts,md}\" --write",
     "test:types": "tsc --noEmit",
     "test:lint": "eslint \"**/*.{tsx,ts}\"",
-    "test:format": "prettier \"**/*.{tsx,ts,md}\" --check",
+    "test:format": "prettier \"**/*.{tsx,ts,md}\" --check --log-level=debug",
     "postinstall": "husky install",
     "precommit": "lint-staged"
   },

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -87,8 +87,8 @@ const SiteMenu = styled.button<{ $lightTheme: boolean }>`
    */
   height: calc(12px + ${() => GRID_GAP_MOBILE});
   width: calc(12px + ${() => GRID_GAP_MOBILE});
-  transformY: translate(calc(${() => GRID_GAP_MOBILE} / 2));
-  
+  transform: translateY(calc(${() => GRID_GAP_MOBILE} / 2));
+
   ${up('md')} {
     height: calc(12px + ${() => GRID_GAP_DESKTOP});
     width: calc(12px + ${() => GRID_GAP_DESKTOP});

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -77,21 +77,22 @@ const SiteTitle = styled(Link)<{ $lightTheme: boolean }>`
 const SiteMenu = styled.button<{ $lightTheme: boolean }>`
   all: unset;
   cursor: pointer;
-  z-index: ${FLYOUT_Z_INDEX};
+  z-index: ${FLYOUT_Z_INDEX + 1};
 
+  display: grid;
+  place-items: center;
   /**
    * to make it simpler to click (especially on mobile),
    * we make the button extra large
    */
-  height: 16px;
-  width: 35px;
-  text-align: right;
-  margin-right: -${() => GRID_GAP_MOBILE};
-  padding-right: ${() => GRID_GAP_MOBILE};
-
+  height: calc(12px + ${() => GRID_GAP_MOBILE});
+  width: calc(12px + ${() => GRID_GAP_MOBILE});
+  transform: translate(calc(${() => GRID_GAP_MOBILE} / 2), calc(-1 * ${() => GRID_GAP_MOBILE} / 2));
+  
   ${up('md')} {
-    margin-right: -${() => GRID_GAP_DESKTOP};
-    padding-right: ${() => GRID_GAP_DESKTOP};
+    height: calc(12px + ${() => GRID_GAP_DESKTOP});
+    width: calc(12px + ${() => GRID_GAP_DESKTOP});
+    transform: translate(calc(${() => GRID_GAP_DESKTOP} / 2), calc(-1 * ${() => GRID_GAP_DESKTOP} / 2));
   }
 
   .bar {

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -87,12 +87,12 @@ const SiteMenu = styled.button<{ $lightTheme: boolean }>`
    */
   height: calc(12px + ${() => GRID_GAP_MOBILE});
   width: calc(12px + ${() => GRID_GAP_MOBILE});
-  transform: translate(calc(${() => GRID_GAP_MOBILE} / 2), calc(-1 * ${() => GRID_GAP_MOBILE} / 2));
+  transformY: translate(calc(${() => GRID_GAP_MOBILE} / 2));
   
   ${up('md')} {
     height: calc(12px + ${() => GRID_GAP_DESKTOP});
     width: calc(12px + ${() => GRID_GAP_DESKTOP});
-    transform: translate(calc(${() => GRID_GAP_DESKTOP} / 2), calc(-1 * ${() => GRID_GAP_DESKTOP} / 2));
+    transform: translateY(calc(${() => GRID_GAP_DESKTOP} / 2));
   }
 
   .bar {

--- a/src/components/legacy/icons/header-icons/burger-menu.tsx
+++ b/src/components/legacy/icons/header-icons/burger-menu.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { GRID_GAP_DESKTOP, GRID_GAP_MOBILE } from '../../../layout/theme';
-import { up } from '../../../support/breakpoint';
 
 interface BurgerMenuProps {
   transition: boolean;
   setHoverTransition: () => void;
 }
+
 export const BurgerMenu = ({
   transition,
   setHoverTransition,

--- a/src/components/legacy/icons/header-icons/burger-menu.tsx
+++ b/src/components/legacy/icons/header-icons/burger-menu.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div<{ $transition: boolean }>`
   align-items: flex-end;
   justify-content: center;
   gap: 2px;
-  
+
   .bar {
     height: 2px;
     background-color: white;

--- a/src/components/legacy/icons/header-icons/burger-menu.tsx
+++ b/src/components/legacy/icons/header-icons/burger-menu.tsx
@@ -21,22 +21,16 @@ export const BurgerMenu = ({
 };
 
 const Wrapper = styled.div<{ $transition: boolean }>`
+  height: 12px;
+  width: 12px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  padding: 3px 0px;
-
-  margin-right: -${() => GRID_GAP_MOBILE};
-  padding-right: ${() => GRID_GAP_MOBILE};
-
-  ${up('md')} {
-    margin-right: -${() => GRID_GAP_DESKTOP};
-    padding-right: ${() => GRID_GAP_DESKTOP};
-  }
-
+  justify-content: center;
+  gap: 2px;
+  
   .bar {
     height: 2px;
-    margin-bottom: 2px;
     background-color: white;
     border-radius: 2px;
   }


### PR DESCRIPTION
The button was hidden by the block with menu on the short screens.  
https://github.com/user-attachments/assets/2a24cd9c-255e-47a4-829e-0150bdc09494

The height of the button was quite small. I've increased it and made the active area a square.
<img width="187" alt="SCR-20241107-jeba" src="https://github.com/user-attachments/assets/a7a73337-c901-45b4-ad2a-7f9499f67b3d">
<img width="411" alt="SCR-20241107-jdyh" src="https://github.com/user-attachments/assets/abbfb51c-9e58-4836-83f5-9918cbccc4e4">
