### PR TITLE
fix (a11y): add aria-hidden to chevron in language-switch

### DIFF
--- a/src/components/layout/header/language-switch.tsx
+++ b/src/components/layout/header/language-switch.tsx
@@ -50,7 +50,11 @@ export const LanguageSwitch = ({
 
   return (
     <StyledNav className={className}>
-      <StyledChevron isEnglish={language === 'en'} show="caret_squared_down" />
+      <StyledChevron
+        isEnglish={language === 'en'}
+        show="caret_squared_down"
+        ariaHidden={true}
+      />
       <StyledSelection
         onChange={(event) => {
           changeLanguage(event.target.value);


### PR DESCRIPTION
This pull request includes a small change to the `src/components/layout/header/language-switch.tsx` file to enhance accessibility by adding an `ariaHidden` attribute to the `StyledChevron` component.

* [`src/components/layout/header/language-switch.tsx`](diffhunk://#diff-98fdce1594de1ddb1bfc489061ec3bf21da8f6af2dbf6d2b7bc53071a75f9e41L53-R57): Added the `ariaHidden` attribute to the `StyledChevron` component to improve accessibility.