### PR TITLE
fix (a11y): add aria-labeled by to accordion button

### DIFF
--- a/src/components/ui/accordion/accordion-header.tsx
+++ b/src/components/ui/accordion/accordion-header.tsx
@@ -58,8 +58,8 @@ export const AccordionHeader = (props: AccordionHeaderProps) => {
   const { isExpanded } = useAccordionItemContext();
 
   return (
-    <AccordionButton aria-labelledby={props.children}>
-      <AccordionTitleHeadline id={props.children}>
+    <AccordionButton aria-labelledby={String(props.children)}>
+      <AccordionTitleHeadline id={String(props.children)}>
         {props.children}
       </AccordionTitleHeadline>
       <StyledIcon open={isExpanded} show="chevron_up" ariaHidden={true} />

--- a/src/components/ui/accordion/accordion-header.tsx
+++ b/src/components/ui/accordion/accordion-header.tsx
@@ -58,8 +58,10 @@ export const AccordionHeader = (props: AccordionHeaderProps) => {
   const { isExpanded } = useAccordionItemContext();
 
   return (
-    <AccordionButton>
-      <AccordionTitleHeadline>{props.children}</AccordionTitleHeadline>
+    <AccordionButton aria-labelledby={props.children}>
+      <AccordionTitleHeadline id={props.children}>
+        {props.children}
+      </AccordionTitleHeadline>
       <StyledIcon open={isExpanded} show="chevron_up" ariaHidden={true} />
     </AccordionButton>
   );


### PR DESCRIPTION
This pull request includes an accessibility improvement to the `AccordionHeader` component in the `src/components/ui/accordion/accordion-header.tsx` file. The changes ensure that the accordion header is properly labeled for screen readers.

Accessibility improvement:

* [`src/components/ui/accordion/accordion-header.tsx`](diffhunk://#diff-2cd65c7554587ff96c304df9af66b958f06362a7a03b9c3939bfccb518699e11L61-R64): Added `aria-labelledby` and `id` attributes to the `AccordionButton` and `AccordionTitleHeadline` elements to enhance accessibility.