### PR TITLE
fix: update OrderedList prop name for styled component

### DIFF
--- a/src/components/legacy/markdown/custom-components.tsx
+++ b/src/components/legacy/markdown/custom-components.tsx
@@ -40,9 +40,9 @@ const UnorderedList = styled.ul`
   }
 `;
 
-const OrderedList = styled.ol<{ doubleDigit: boolean }>`
+const OrderedList = styled.ol<{ $doubleDigit: boolean }>`
   line-height: 150%;
-  padding-left: ${(props) => (props.doubleDigit ? '26px' : '18px')};
+  padding-left: ${(props) => (props.$doubleDigit ? '26px' : '18px')};
   margin: 0 0 16px;
 
   > li > p {
@@ -194,7 +194,7 @@ const customSatellytesComponents = {
   },
   ol(props) {
     return (
-      <OrderedList doubleDigit={props.children.length > 9}>
+      <OrderedList $doubleDigit={props.children.length > 9}>
         {props.children}
       </OrderedList>
     );


### PR DESCRIPTION
This PR fixes the issue that the prop `doubleDigit` get's passed to the unstyled component by styled-components. Prefixing the prop with $ fixes that.

Changes:

* [`src/components/legacy/markdown/custom-components.tsx`](diffhunk://#diff-79361511b3a8b1f3732aed642318346916bada00a522b3358f3e10dbf38017a4L43-R45): Renamed the `doubleDigit` prop to `$doubleDigit` in the `OrderedList` component definition and updated the prop usage in the `padding-left` style.
* [`src/components/legacy/markdown/custom-components.tsx`](diffhunk://#diff-79361511b3a8b1f3732aed642318346916bada00a522b3358f3e10dbf38017a4L197-R197): Updated the `OrderedList` component usage to pass the renamed `$doubleDigit` prop.

Console output before fix: 
![image](https://github.com/user-attachments/assets/20814c42-9498-428f-98a5-27a1af7a4223)
