### PR TITLE
fix: center menu icon vertically

### DIFF
--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -79,20 +79,19 @@ const SiteMenu = styled.button<{ $lightTheme: boolean }>`
   cursor: pointer;
   z-index: ${FLYOUT_Z_INDEX + 1};
 
-  display: grid;
-  place-items: center;
   /**
    * to make it simpler to click (especially on mobile),
    * we make the button extra large
    */
-  height: calc(12px + ${() => GRID_GAP_MOBILE});
-  width: calc(12px + ${() => GRID_GAP_MOBILE});
-  transform: translateY(calc(${() => GRID_GAP_MOBILE} / 2));
+  height: 16px;
+  width: 35px;
+  text-align: right;
+  margin-right: -${() => GRID_GAP_MOBILE};
+  padding-right: ${() => GRID_GAP_MOBILE};
 
   ${up('md')} {
-    height: calc(12px + ${() => GRID_GAP_DESKTOP});
-    width: calc(12px + ${() => GRID_GAP_DESKTOP});
-    transform: translateY(calc(${() => GRID_GAP_DESKTOP} / 2));
+    margin-right: -${() => GRID_GAP_DESKTOP};
+    padding-right: ${() => GRID_GAP_DESKTOP};
   }
 
   .bar {

--- a/src/components/legacy/icons/header-icons/burger-menu.tsx
+++ b/src/components/legacy/icons/header-icons/burger-menu.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { GRID_GAP_DESKTOP, GRID_GAP_MOBILE } from '../../../layout/theme';
+import { up } from '../../../support/breakpoint';
 
 interface BurgerMenuProps {
   transition: boolean;
@@ -20,13 +22,19 @@ export const BurgerMenu = ({
 };
 
 const Wrapper = styled.div<{ $transition: boolean }>`
-  height: 12px;
-  width: 12px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  justify-content: center;
   gap: 2px;
+
+  padding: 3px 0;
+
+  margin-right: -${() => GRID_GAP_MOBILE};
+  padding-right: ${() => GRID_GAP_MOBILE};
+  ${up('md')} {
+    margin-right: -${() => GRID_GAP_DESKTOP};
+    padding-right: ${() => GRID_GAP_DESKTOP};
+  }
 
   .bar {
     height: 2px;
@@ -44,7 +52,6 @@ const Wrapper = styled.div<{ $transition: boolean }>`
 
   .bar:nth-child(3) {
     width: 8px;
-    margin-bottom: 0px;
   }
 
   @media (pointer: fine) {


### PR DESCRIPTION
### What was the problem?

The changes in https://github.com/satellytes/satellytes.com/pull/832 broke the alignment of the menu icon. Unfortunately, I missed that during the review. 

### How is it fixed?

The changes of https://github.com/satellytes/satellytes.com/pull/832 that do not affect the `z-index` are reverted. This way we have the best of both worlds. 

### Preview
Before this PR:
<img width="535" alt="Screenshot 2024-11-29 at 14 39 39" src="https://github.com/user-attachments/assets/c64ba78b-601a-4606-a53e-9b55848bcedb">
After this PR:
<img width="525" alt="Screenshot 2024-11-29 at 14 39 46" src="https://github.com/user-attachments/assets/1d6b5187-fddb-42d3-b9e0-3ce6f224fd53">
